### PR TITLE
New priors on theta matrix

### DIFF
--- a/src/pmhn/__init__.py
+++ b/src/pmhn/__init__.py
@@ -12,7 +12,7 @@ from pmhn._backend import (
 from pmhn._ppl import (
     MHNLoglikelihood,
     PersonalisedMHNLoglikelihood,
-    construct_regularized_horseshoe,
+    prior_regularized_horseshoe,
 )
 from pmhn._theta import construct_matrix, decompose_matrix, sample_spike_and_slab
 from pmhn._visualise import (
@@ -38,7 +38,7 @@ __all__ = [
     "construct_matrix",
     "decompose_matrix",
     "sample_spike_and_slab",
-    "construct_regularized_horseshoe",
+    "prior_regularized_horseshoe",
     "plot_genotypes",
     "plot_genotype_samples",
     "plot_theta",

--- a/src/pmhn/__init__.py
+++ b/src/pmhn/__init__.py
@@ -13,6 +13,8 @@ from pmhn._ppl import (
     MHNLoglikelihood,
     PersonalisedMHNLoglikelihood,
     prior_regularized_horseshoe,
+    prior_normal,
+    prior_only_baseline_rates,
 )
 from pmhn._theta import construct_matrix, decompose_matrix, sample_spike_and_slab
 from pmhn._visualise import (
@@ -39,6 +41,8 @@ __all__ = [
     "decompose_matrix",
     "sample_spike_and_slab",
     "prior_regularized_horseshoe",
+    "prior_normal",
+    "prior_only_baseline_rates",
     "plot_genotypes",
     "plot_genotype_samples",
     "plot_theta",

--- a/src/pmhn/_ppl/__init__.py
+++ b/src/pmhn/_ppl/__init__.py
@@ -2,10 +2,10 @@
 probabilistic programming languages (PPLs)."""
 from pmhn._ppl._singlemhn import MHNLoglikelihood
 from pmhn._ppl._multiplemhn import PersonalisedMHNLoglikelihood
-from pmhn._ppl._priors import construct_regularized_horseshoe
+from pmhn._ppl._priors import prior_regularized_horseshoe
 
 __all__ = [
     "MHNLoglikelihood",
     "PersonalisedMHNLoglikelihood",
-    "construct_regularized_horseshoe",
+    "prior_regularized_horseshoe",
 ]

--- a/src/pmhn/_ppl/__init__.py
+++ b/src/pmhn/_ppl/__init__.py
@@ -2,10 +2,16 @@
 probabilistic programming languages (PPLs)."""
 from pmhn._ppl._singlemhn import MHNLoglikelihood
 from pmhn._ppl._multiplemhn import PersonalisedMHNLoglikelihood
-from pmhn._ppl._priors import prior_regularized_horseshoe
+from pmhn._ppl._priors import (
+    prior_regularized_horseshoe,
+    prior_normal,
+    prior_only_baseline_rates,
+)
 
 __all__ = [
     "MHNLoglikelihood",
     "PersonalisedMHNLoglikelihood",
     "prior_regularized_horseshoe",
+    "prior_normal",
+    "prior_only_baseline_rates",
 ]

--- a/src/pmhn/_ppl/_priors.py
+++ b/src/pmhn/_ppl/_priors.py
@@ -6,7 +6,7 @@ import pymc as pm
 import pytensor.tensor as pt
 
 
-def construct_regularized_horseshoe(
+def prior_regularized_horseshoe(
     n_mutations: int,
     baselines_mean: float = 0,
     baselines_sigma: float = 3.0,
@@ -32,7 +32,7 @@ def construct_regularized_horseshoe(
            which has shape (n_mutations, n_mutations)
 
     Example:
-        >>> model = construct_regularized_horseshoe(n_mutations=10)
+        >>> model = prior_regularized_horseshoe(n_mutations=10)
         >>> with model:
         >>>     theta = model.theta
         >>>     pm.Potential("potential", some_function_of(theta))

--- a/tests/ppl/test_priors.py
+++ b/tests/ppl/test_priors.py
@@ -4,7 +4,7 @@ import pmhn._ppl._priors as priors
 
 
 def test_regularized_horseshoe(n_mutations: int = 5) -> None:
-    model = priors.construct_regularized_horseshoe(n_mutations=n_mutations)
+    model = priors.prior_regularized_horseshoe(n_mutations=n_mutations)
 
     assert hasattr(model, "theta")
 

--- a/tests/ppl/test_priors.py
+++ b/tests/ppl/test_priors.py
@@ -1,10 +1,21 @@
 import pymc as pm
+import pytest
 
 import pmhn._ppl._priors as priors
 
 
-def test_regularized_horseshoe(n_mutations: int = 5) -> None:
-    model = priors.prior_regularized_horseshoe(n_mutations=n_mutations)
+@pytest.mark.parametrize(
+    "model_factory",
+    [
+        priors.prior_only_baseline_rates,
+        priors.prior_normal,
+        priors.prior_regularized_horseshoe,
+    ],
+)
+def test_basic_prior_test(model_factory, n_mutations: int = 5) -> None:
+    """Tests whether `model.theta` exists
+    and has shape (n_mutations, n_mutations)."""
+    model = model_factory(n_mutations=n_mutations)
 
     assert hasattr(model, "theta")
 

--- a/workflows/mhn-bayes.smk
+++ b/workflows/mhn-bayes.smk
@@ -108,7 +108,7 @@ rule sample_prior:
         rng = np.random.default_rng(settings.prior_sampling_seed)
         n_samples: int = 300
 
-        model = pmhn.construct_regularized_horseshoe(n_mutations=settings.n_mutations)
+        model = pmhn.prior_regularized_horseshoe(n_mutations=settings.n_mutations)
         with model:
             idata = pm.sample_prior_predictive(samples=n_samples, random_seed=rng)
 
@@ -196,7 +196,7 @@ rule generate_samples_for_one_chain:
             backend=pmhn.MHNCythonBackend(),
         )
 
-        model = pmhn.construct_regularized_horseshoe(n_mutations=genotypes.shape[1])
+        model = pmhn.prior_regularized_horseshoe(n_mutations=genotypes.shape[1])
 
         with model:
             pm.Potential("loglikelihood", loglikelihood(model.theta))


### PR DESCRIPTION
This PR adds the following priors on the $\theta$ matrix:
  - Weakly informative normal prior $\theta_{ij}\sim \mathcal N(\mu, \sigma^2)$, with default $\mu=0$ and $\sigma=10$.
  - A prior modelling only the baselines with all $\theta_{ij}=0$ for $i\neq j$.