### PR TITLE
SMC sampling and Laplace prior for MAP estimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ $ poetry shell  # If it is not already active
 $ pre-commit install
 ```
 
-
 ## Acknowledgements
 
-This package is built around [LearnMHN](https://github.com/spang-lab/LearnMHN) (the backend for Mutual Hazard Networks) and [PyMC](https://www.pymc.io/) (probabilistic language framework).
+This package is built around [LearnMHN](https://github.com/spang-lab/LearnMHN) (the backend for Mutual Hazard Networks) and [PyMC](https://www.pymc.io/) (probabilistic programming framework).
 

--- a/src/pmhn/__init__.py
+++ b/src/pmhn/__init__.py
@@ -15,6 +15,7 @@ from pmhn._ppl import (
     prior_regularized_horseshoe,
     prior_normal,
     prior_only_baseline_rates,
+    prior_offdiagonal_laplace,
 )
 from pmhn._theta import construct_matrix, decompose_matrix, sample_spike_and_slab
 from pmhn._visualise import (
@@ -43,6 +44,7 @@ __all__ = [
     "prior_regularized_horseshoe",
     "prior_normal",
     "prior_only_baseline_rates",
+    "prior_offdiagonal_laplace",
     "plot_genotypes",
     "plot_genotype_samples",
     "plot_theta",

--- a/src/pmhn/_ppl/__init__.py
+++ b/src/pmhn/_ppl/__init__.py
@@ -6,6 +6,7 @@ from pmhn._ppl._priors import (
     prior_regularized_horseshoe,
     prior_normal,
     prior_only_baseline_rates,
+    prior_offdiagonal_laplace,
 )
 
 __all__ = [
@@ -14,4 +15,5 @@ __all__ = [
     "prior_regularized_horseshoe",
     "prior_normal",
     "prior_only_baseline_rates",
+    "prior_offdiagonal_laplace",
 ]

--- a/tests/ppl/test_priors.py
+++ b/tests/ppl/test_priors.py
@@ -10,6 +10,7 @@ import pmhn._ppl._priors as priors
         priors.prior_only_baseline_rates,
         priors.prior_normal,
         priors.prior_regularized_horseshoe,
+        priors.prior_offdiagonal_laplace,
     ],
 )
 def test_basic_prior_test(model_factory, n_mutations: int = 5) -> None:


### PR DESCRIPTION
This PR adds the following utilities:
  - [x] SMC sampler for Bayesian inference in MHNs.
  - [x] A Laplace prior on off-diagonal $\theta_{ij}, i\neq j$ terms, resulting in L1 penalty when doing MAP estimation.