### PR TITLE
Add subpackage with template for TreeMHN

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ matplotlib = "^3.7.1"
 seaborn = "^0.12.2"
 pydantic = "^1.10.9"
 netcdf4 = "^1.6.4"
+anytree = "^2.9.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.1"

--- a/src/pmhn/_trees/__init__.py
+++ b/src/pmhn/_trees/__init__.py
@@ -1,0 +1,18 @@
+"""This subpackage contains the implementation of TreeMHN.
+
+Luo, X.G., Kuipers, J. & Beerenwinkel, N.
+"Joint inference of exclusivity patterns
+and recurrent trajectories from tumor mutation trees."
+Nat Commun 14, 3676 (2023).
+https://doi.org/10.1038/s41467-023-39400-w
+"""
+
+from pmhn._trees._simulate import simulate_trees
+from pmhn._trees._interfaces import Tree
+from pmhn._trees._backend import OriginalTreeMHNBackend
+
+__all__ = [
+    "simulate_trees",
+    "Tree",
+    "OriginalTreeMHNBackend",
+]

--- a/src/pmhn/_trees/_backend.py
+++ b/src/pmhn/_trees/_backend.py
@@ -1,0 +1,100 @@
+from typing import Protocol
+
+
+import numpy as np
+
+
+from pmhn._trees._interfaces import Tree
+
+
+class IndividualTreeMHNBackendInterface(Protocol):
+    def loglikelihood(
+        self,
+        tree: Tree,
+        theta: np.ndarray,
+    ) -> float:
+        """Calculates loglikelihood `log P(tree | theta)`.
+
+        Args:
+            tree: a tree
+            theta: real-valued (i.e., log-theta) matrix,
+              shape (n_mutations, n_mutations)
+
+        Returns:
+            loglikelihood of the tree
+        """
+        raise NotImplementedError
+
+    def gradient(
+        self,
+        tree: Tree,
+        theta: np.ndarray,
+    ) -> np.ndarray:
+        """Calculates the partial derivatives of `log P(tree | theta)`
+        with respect to `theta`.
+
+        Args:
+            tree: a tree
+            theta: real-valued matrix,
+              shape (n_mutations, n_mutatations)
+
+        Returns:
+            gradient `d log P(tree | theta) / d theta`,
+              shape (n_mutations, n_mutations)
+        """
+        raise NotImplementedError
+
+    def gradient_and_loglikelihood(
+        self, tree: Tree, theta: np.ndarray
+    ) -> tuple[np.ndarray, float]:
+        """Returns the gradient and the loglikelihood.
+
+        Note:
+            This function may be faster than calling `gradient` and `loglikelihood`
+            separately.
+        """
+        return self.gradient(tree, theta), self.loglikelihood(tree, theta)
+
+
+class OriginalTreeMHNBackend(IndividualTreeMHNBackendInterface):
+    def loglikelihood(
+        self,
+        tree: Tree,
+        theta: np.ndarray,
+    ) -> float:
+        """Calculates loglikelihood `log P(tree | theta)`.
+
+        Args:
+            tree: a tree
+            theta: real-valued (i.e., log-theta) matrix,
+              shape (n_mutations, n_mutations)
+
+        Returns:
+            loglikelihood of the tree
+        """
+        # TODO(Laurenz): This implementation is missing and is a priority.
+        #   It can be implemented in any way.
+        raise NotImplementedError
+
+    def gradient(self, tree: Tree, theta: np.ndarray) -> np.ndarray:
+        """Calculates the partial derivatives of `log P(tree | theta)`
+        with respect to `theta`.
+
+        Args:
+            tree: a tree
+            theta: real-valued matrix, shape (n_mutations, n_mutatations)
+
+        Returns:
+            gradient `d log P(tree | theta) / d theta`,
+              shape (n_mutations, n_mutations)
+        """
+        # TODO(Laurenz, Pawel): This implementation is missing,
+        #    but it is *not* a priority.
+        #    We will try to do the modelling as soon as possible,
+        #    starting with a sequential Monte Carlo sampler
+        #    and Metropolis transitions.
+        #    Only after initial experiments
+        #    (we will probably see that it's not scalable),
+        #    we'll consider switching to Hamiltonian Monte Carlo,
+        #    which requires gradients.
+        raise NotImplementedError

--- a/src/pmhn/_trees/_backend.py
+++ b/src/pmhn/_trees/_backend.py
@@ -72,7 +72,7 @@ class OriginalTreeMHNBackend(IndividualTreeMHNBackendInterface):
         Returns:
             loglikelihood of the tree
         """
-        # TODO(Laurenz): This implementation is missing and is a priority.
+        # TODO(Pawel): this is part of https://github.com/cbg-ethz/pMHN/issues/15
         #   It can be implemented in any way.
         raise NotImplementedError
 
@@ -88,7 +88,8 @@ class OriginalTreeMHNBackend(IndividualTreeMHNBackendInterface):
             gradient `d log P(tree | theta) / d theta`,
               shape (n_mutations, n_mutations)
         """
-        # TODO(Laurenz, Pawel): This implementation is missing,
+        # TODO(Pawel): This is part of
+        #    https://github.com/cbg-ethz/pMHN/issues/18,
         #    but it is *not* a priority.
         #    We will try to do the modelling as soon as possible,
         #    starting with a sequential Monte Carlo sampler

--- a/src/pmhn/_trees/_interfaces.py
+++ b/src/pmhn/_trees/_interfaces.py
@@ -1,0 +1,6 @@
+"""Interfaces."""
+from typing import TypeAlias
+from anytree import Node
+
+
+Tree: TypeAlias = Node

--- a/src/pmhn/_trees/_simulate.py
+++ b/src/pmhn/_trees/_simulate.py
@@ -1,0 +1,89 @@
+from typing import Union, Sequence
+
+import numpy as np
+
+from pmhn._trees._interfaces import Tree
+
+
+def _simulate_tree(
+    rng,
+    theta: np.ndarray,
+    sampling_time: float,
+) -> Tree:
+    """Simulates a single tree with known sampling time.
+
+    Args:
+        rng: random number generator
+        theta: real-valued (i.e., log-theta) matrix,
+          shape (n_mutations, n_mutations)
+        sampling_time: known sampling time
+
+    Returns:
+        a mutation tree
+
+    Note:
+        We assume that sampling time $t_s$ is known.
+        Otherwise, this is the Algorithm 1 from in
+        Appendix A1 to the TreeMHN paper
+        (with the difference that in the paper `Theta_{jl}`
+        is used, which is `Theta_{jl} = exp( theta_{jl} )`.
+    """
+    # TODO(Laurenz): This implementation is missing and is a priority.
+    #   Note that the sampling time is known that our `theta` entries
+    #   are log-Theta entries from the paper.
+    raise NotImplementedError
+
+
+def simulate_trees(
+    rng,
+    n_points: int,
+    theta: np.ndarray,
+    mean_sampling_time: Union[np.ndarray, float, Sequence[float]],
+) -> tuple[np.ndarray, list[Tree]]:
+    """Simulates a data set of trees with known sampling times.
+
+    Args:
+        n_points: number of trees to simulate.
+        theta: the log-MHN matrix. Can be of shape (n_mutations, n_mutations)
+            or (n_points, n_mutations, n_mutations).
+        mean_sampling_time: the mean sampling time.
+            Can be a float (shared between all data point)
+            or an array of shape (n_points,).
+
+    Returns:
+        sampling times, shape (n_points,)
+        sampled trees, list of length `n_points`
+    """
+    if n_points < 1:
+        raise ValueError("n_trees must be at least 1")
+
+    assert len(theta.shape) in {
+        2,
+        3,
+    }, "Theta should have shape (m, m) or (n_points, m, m)."
+
+    # Make sure mean_sampling_time is an array of shape (n_points,)
+    if isinstance(mean_sampling_time, float):
+        mean_sampling_time = np.full(n_points, fill_value=mean_sampling_time)
+    else:
+        mean_sampling_time = np.asarray(mean_sampling_time)
+
+    assert (
+        len(mean_sampling_time) == n_points
+    ), "mean_sampling_time should have length n_points."
+
+    # Make sure theta has shape (n_points, n, n)
+    if len(theta.shape) == 2:
+        theta = np.asarray([theta for _ in range(n_points)])
+
+    assert theta.shape[0] == n_points, "Theta should have shape (n_points, n, n)."
+    assert theta.shape[1] == theta.shape[2], "Each theta should be square."
+
+    sampling_times = rng.exponential(scale=mean_sampling_time, size=n_points)
+
+    trees = [
+        _simulate_tree(rng, theta=th, sampling_time=t_s)
+        for th, t_s in zip(theta, sampling_times)
+    ]
+
+    return sampling_times, trees

--- a/src/pmhn/_trees/_simulate.py
+++ b/src/pmhn/_trees/_simulate.py
@@ -28,7 +28,7 @@ def _simulate_tree(
         (with the difference that in the paper `Theta_{jl}`
         is used, which is `Theta_{jl} = exp( theta_{jl} )`.
     """
-    # TODO(Laurenz): This implementation is missing and is a priority.
+    # TODO(Pawel): This is part of https://github.com/cbg-ethz/pMHN/issues/14
     #   Note that the sampling time is known that our `theta` entries
     #   are log-Theta entries from the paper.
     raise NotImplementedError

--- a/src/pmhn/_trees/_validate.py
+++ b/src/pmhn/_trees/_validate.py
@@ -1,0 +1,46 @@
+"""Tree validation utilities."""
+from pmhn._trees._interfaces import Tree
+
+
+def _validate_repeated_mutations_in_lineage(tree: Tree) -> bool:
+    """Validates that there are no repeated mutations in a lineage:
+
+        A -> X -> C -> D -> X -> ...
+
+    Args:
+        tree: the tree to validate.
+
+    Returns:
+        True if the tree is valid, False otherwise.
+    """
+    # TODO(Pawel): part of https://github.com/cbg-ethz/pMHN/issues/17
+    raise NotImplementedError
+
+
+def _validate_identical_siblings(tree: Tree) -> bool:
+    """Validates if there are no identical siblings:
+
+        X <- A -> X -> B
+
+    Args:
+        tree: the tree to validate.
+
+    Returns:
+        True if the tree is valid, False otherwise.
+    """
+    # TODO(Pawel): part of https://github.com/cbg-ethz/pMHN/issues/17
+    raise NotImplementedError
+
+
+def validate_tree(tree: Tree) -> bool:
+    """Validates a tree.
+
+    Args:
+        tree: the tree to validate.
+
+    Returns:
+        True if the tree is valid, False otherwise.
+    """
+    return _validate_identical_siblings(
+        tree
+    ) and _validate_repeated_mutations_in_lineage(tree)

--- a/tests/trees/test_backend.py
+++ b/tests/trees/test_backend.py
@@ -1,0 +1,81 @@
+import numpy as np
+import pytest
+
+import pmhn._trees as trees
+
+
+def get_all_backends() -> list:
+    return [trees.OriginalTreeMHNBackend()]
+
+
+@pytest.mark.skip("TODO(Laurenz): this implementation is missing and is a priority")
+def test_loglikelihood_example_1() -> None:
+    """Tests if the loglikelihood is calculated properly
+    on a simple example:
+
+        root -> 0 -> 1
+    """
+    raise NotImplementedError
+
+
+@pytest.mark.skip("TODO(Laurenz): this implementation is missing and is a priority")
+def test_loglikelihood_example_2() -> None:
+    """Tests if the loglikelihood is calculated properly
+    on a simple example:
+
+      0 <- root -> 1 -> 0
+    """
+    raise NotImplementedError
+
+
+@pytest.mark.skip(
+    """TODO(Laurenz): this implementation is missing and is a priority.
+    I'd suggest to sample a tree from TreeMHN,
+    evaluate its loglikelihood against some simple matrix
+    (e.g., the entries can be 0, +-0.5, and +-1)
+    and then manually encode both the matrix, the tree and the loglikelihood here.
+    Remember that TreeMHN package uses 'large Theta' 
+    and we use 'small theta' convention.
+    """
+)
+def test_loglikelihood_larger_tree_1() -> None:
+    """This test compares the loglikelihood of a larger tree (with 5 mutations)
+    against the value provided by the TreeMHN package in R:
+    https://github.com/cbg-ethz/TreeMHN"""
+
+
+@pytest.mark.skip(
+    """TODO(Laurenz): this test is skipped 
+    until the implementation of the loglikelihood is ready"""
+)
+@pytest.mark.parametrize("backend", get_all_backends())
+@pytest.mark.parametrize("n_mutations", (2, 5))
+def test_loglikelihood_empty_tree(backend, n_mutations: int) -> None:
+    """Tests if the loglikelihood of a tree without mutations is well-defined."""
+    root = trees.Tree("root")
+    rng = np.random.default_rng(0)
+
+    theta = rng.normal(size=(n_mutations, n_mutations))
+
+    loglike = backend.loglikelihood(root, theta)
+    assert isinstance(loglike, float)
+
+
+@pytest.mark.skip("TODO(Laurenz, Pawel): this implementation is *not* a priority")
+def test_gradient_example_1() -> None:
+    """Tests if the gradient loglikelihood is calculated properly
+    on a simple example:
+
+        root -> 0 -> 1
+    """
+    raise NotImplementedError
+
+
+@pytest.mark.skip("TODO(Laurenz): this implementation is *not* a priority")
+def test_gradient_example_2() -> None:
+    """Tests if the loglikelihood is calculated properly
+    on a simple example:
+
+      0 <- root -> 1 -> 0
+    """
+    raise NotImplementedError

--- a/tests/trees/test_backend.py
+++ b/tests/trees/test_backend.py
@@ -8,7 +8,7 @@ def get_all_backends() -> list:
     return [trees.OriginalTreeMHNBackend()]
 
 
-@pytest.mark.skip("TODO(Laurenz): this implementation is missing and is a priority")
+@pytest.mark.skip("TODO(Pawel): part of https://github.com/cbg-ethz/pMHN/issues/15")
 def test_loglikelihood_example_1() -> None:
     """Tests if the loglikelihood is calculated properly
     on a simple example:
@@ -18,7 +18,7 @@ def test_loglikelihood_example_1() -> None:
     raise NotImplementedError
 
 
-@pytest.mark.skip("TODO(Laurenz): this implementation is missing and is a priority")
+@pytest.mark.skip("TODO(Pawel): part of https://github.com/cbg-ethz/pMHN/issues/15")
 def test_loglikelihood_example_2() -> None:
     """Tests if the loglikelihood is calculated properly
     on a simple example:
@@ -29,7 +29,7 @@ def test_loglikelihood_example_2() -> None:
 
 
 @pytest.mark.skip(
-    """TODO(Laurenz): this implementation is missing and is a priority.
+    """TODO(Pawel): part of https://github.com/cbg-ethz/pMHN/issues/15
     I'd suggest to sample a tree from TreeMHN,
     evaluate its loglikelihood against some simple matrix
     (e.g., the entries can be 0, +-0.5, and +-1)
@@ -42,12 +42,10 @@ def test_loglikelihood_larger_tree_1() -> None:
     """This test compares the loglikelihood of a larger tree (with 5 mutations)
     against the value provided by the TreeMHN package in R:
     https://github.com/cbg-ethz/TreeMHN"""
+    raise NotImplementedError
 
 
-@pytest.mark.skip(
-    """TODO(Laurenz): this test is skipped 
-    until the implementation of the loglikelihood is ready"""
-)
+@pytest.mark.skip("TODO(Pawel): part of https://github.com/cbg-ethz/pMHN/issues/15")
 @pytest.mark.parametrize("backend", get_all_backends())
 @pytest.mark.parametrize("n_mutations", (2, 5))
 def test_loglikelihood_empty_tree(backend, n_mutations: int) -> None:
@@ -61,7 +59,7 @@ def test_loglikelihood_empty_tree(backend, n_mutations: int) -> None:
     assert isinstance(loglike, float)
 
 
-@pytest.mark.skip("TODO(Laurenz, Pawel): this implementation is *not* a priority")
+@pytest.mark.skip("TODO(Pawel): part of https://github.com/cbg-ethz/pMHN/issues/18")
 def test_gradient_example_1() -> None:
     """Tests if the gradient loglikelihood is calculated properly
     on a simple example:
@@ -71,7 +69,7 @@ def test_gradient_example_1() -> None:
     raise NotImplementedError
 
 
-@pytest.mark.skip("TODO(Laurenz): this implementation is *not* a priority")
+@pytest.mark.skip("TODO(Pawel): part of https://github.com/cbg-ethz/pMHN/issues/18")
 def test_gradient_example_2() -> None:
     """Tests if the loglikelihood is calculated properly
     on a simple example:

--- a/tests/trees/test_interface.py
+++ b/tests/trees/test_interface.py
@@ -1,0 +1,17 @@
+from pmhn._trees import Tree
+
+
+def test_create_tree_mutation_occurs_twice() -> None:
+    """
+    We want to see if a tree with a mutation occuring twice can be created:
+        root
+        ├── 0
+        │   └── 1
+        └── 1
+    """
+    root = Tree("root")
+    zero = Tree(0, parent=root)
+    Tree(1, parent=zero)
+    Tree(1, parent=root)
+
+    assert [node.name for node in root.leaves] == [1, 1]

--- a/tests/trees/test_validate.py
+++ b/tests/trees/test_validate.py
@@ -6,7 +6,7 @@ from pmhn._trees._validate import validate_tree
 
 def valid_trees() -> list[Tree]:
     """A list of valid trees."""
-    raise NotImplementedError
+    return []
 
 
 @pytest.mark.skip(
@@ -26,7 +26,7 @@ def test_valid_tree_is_valid(tree: Tree) -> None:
 
 def trees_identical_siblings() -> list[Tree]:
     """A list of trees with identical siblings."""
-    raise NotImplementedError
+    return []
 
 
 @pytest.mark.skip(
@@ -42,7 +42,7 @@ def test_invalid_tree_identical_siblings(tree: Tree) -> None:
 
 def trees_repeated_mutations_in_lineage() -> list[Tree]:
     """A list of trees with repeated mutations in a lineage."""
-    raise NotImplementedError
+    return []
 
 
 @pytest.mark.skip(

--- a/tests/trees/test_validate.py
+++ b/tests/trees/test_validate.py
@@ -1,0 +1,55 @@
+import pytest
+
+from pmhn._trees._interfaces import Tree
+from pmhn._trees._validate import validate_tree
+
+
+def valid_trees() -> list[Tree]:
+    """A list of valid trees."""
+    raise NotImplementedError
+
+
+@pytest.mark.skip(
+    """TODO(Pawel): this test is skipped 
+    until the implementation of the validation is ready.
+    Part of https://github.com/cbg-ethz/pMHN/issues/17 
+    """
+)
+@pytest.mark.skip(
+    "This test is skipped until the implementation of the validation is ready"
+)
+@pytest.mark.parametrize("tree", valid_trees())
+def test_valid_tree_is_valid(tree: Tree) -> None:
+    """Checks if the valid trees are valid."""
+    assert validate_tree(tree)
+
+
+def trees_identical_siblings() -> list[Tree]:
+    """A list of trees with identical siblings."""
+    raise NotImplementedError
+
+
+@pytest.mark.skip(
+    """TODO(Pawel): this test is skipped 
+    until the implementation of the validation is ready.
+    Part of https://github.com/cbg-ethz/pMHN/issues/17"""
+)
+@pytest.mark.parametrize("tree", trees_identical_siblings())
+def test_invalid_tree_identical_siblings(tree: Tree) -> None:
+    """Checks if the trees with identical siblings are invalid."""
+    assert not validate_tree(tree)
+
+
+def trees_repeated_mutations_in_lineage() -> list[Tree]:
+    """A list of trees with repeated mutations in a lineage."""
+    raise NotImplementedError
+
+
+@pytest.mark.skip(
+    """TODO(Pawel): this test is skipped 
+    until the implementation of the validation is ready
+    Part of https://github.com/cbg-ethz/pMHN/issues/17"""
+)
+@pytest.mark.parametrize("tree", trees_repeated_mutations_in_lineage())
+def test_invalid_tree_repeated_mutations_in_lineage(tree: Tree) -> None:
+    assert not validate_tree(tree)


### PR DESCRIPTION
Hi Xiang,

I've added some "missing bits" to the package, which I find good "first tasks" in the project. I hope that they are sufficiently well-explained, but any suggestions how to improve them would be wonderful :slightly_smiling_face: 

I think we can make "closing the loop" the priority, i.e., the minimal viable product would be doing some experiments with Bayesian inference on small simulated data sets.

This stage (hopefully no longer than the first three weeks) would consist of:
  - Implementing `Algorithm 1` from the paper (tree generation) and simulating a small data set (e.g., 200 trees from a $5\times 5$ network with known diagonal and four off-diagonal terms).
  - Implementing loglikelihood calculation (using matrix inversion or forward substitution – at this stage we don't need the gradient).
  - Adjusting the (ordinary) MHN Snakemake workflow so that we can use gradient-free sequential Monte Carlo sampler to sample from the posterior.

What do you think about it? I think the next steps would be to move to gradient-based inference (Hamiltonian Monte Carlo) and then modelling more complex data.