### PR TITLE
Add more priors encouraging sparsity

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -14,9 +14,11 @@
 ::: pmhn.PersonalisedMHNLoglikelihood
 
 ## Priors
+::: pmhn.prior_horseshoe
 ::: pmhn.prior_regularized_horseshoe
 ::: pmhn.prior_normal
 ::: pmhn.prior_only_baseline_rates
+::: pmhn.prior_spike_and_slab_marginalized
 
 ## Visualisations
 ### Mutual Hazard Network matrices

--- a/src/pmhn/__init__.py
+++ b/src/pmhn/__init__.py
@@ -16,6 +16,8 @@ from pmhn._ppl import (
     prior_normal,
     prior_only_baseline_rates,
     prior_offdiagonal_laplace,
+    prior_spike_and_slab_marginalized,
+    prior_horseshoe,
 )
 from pmhn._theta import construct_matrix, decompose_matrix, sample_spike_and_slab
 from pmhn._visualise import (
@@ -41,10 +43,12 @@ __all__ = [
     "construct_matrix",
     "decompose_matrix",
     "sample_spike_and_slab",
+    "prior_horseshoe",
     "prior_regularized_horseshoe",
     "prior_normal",
     "prior_only_baseline_rates",
     "prior_offdiagonal_laplace",
+    "prior_spike_and_slab_marginalized",
     "plot_genotypes",
     "plot_genotype_samples",
     "plot_theta",

--- a/src/pmhn/_ppl/__init__.py
+++ b/src/pmhn/_ppl/__init__.py
@@ -7,13 +7,19 @@ from pmhn._ppl._priors import (
     prior_normal,
     prior_only_baseline_rates,
     prior_offdiagonal_laplace,
+    prior_horseshoe,
+    prior_spike_and_slab_marginalized,
+    construct_square_matrix,
 )
 
 __all__ = [
+    "construct_square_matrix",
     "MHNLoglikelihood",
     "PersonalisedMHNLoglikelihood",
     "prior_regularized_horseshoe",
     "prior_normal",
     "prior_only_baseline_rates",
     "prior_offdiagonal_laplace",
+    "prior_horseshoe",
+    "prior_spike_and_slab_marginalized",
 ]

--- a/src/pmhn/_ppl/_priors.py
+++ b/src/pmhn/_ppl/_priors.py
@@ -169,10 +169,12 @@ def prior_regularized_horseshoe(
            which has shape (n_mutations, n_mutations)
 
     Example:
-        >>> model = prior_regularized_horseshoe(n_mutations=10)
-        >>> with model:
-        >>>     theta = model.theta
-        >>>     pm.Potential("potential", some_function_of(theta))
+        ```python
+        model = prior_regularized_horseshoe(n_mutations=10)
+        with model:
+            theta = model.theta
+            pm.Potential("potential", some_function_of(theta))
+        ```
     """
     if sparsity_sigma <= 0:
         raise ValueError("sparsity_sigma must be positive")
@@ -298,8 +300,8 @@ def prior_spike_and_slab_marginalized(
 
     Note:
         By default we set `sparsity` prior Beta(3, 1) for
-        $\\mathbb E[\\gamma] \\approx 0.75$
-        which should result in 75% of the off-diagonal entries being close to zero.
+        $E[\\gamma] \\approx 0.75$, which
+        should result in 75% of the off-diagonal entries being close to zero.
     """
     with pm.Model() as model:
         gamma = pm.Beta("sparsity", sparsity_a, sparsity_b)

--- a/src/pmhn/_ppl/_priors.py
+++ b/src/pmhn/_ppl/_priors.py
@@ -10,9 +10,7 @@ _BASELINE_RATES: str = "baseline_rates"
 _THETA: str = "theta"
 
 
-def construct_square_matrix(
-    n: int, diagonal: pt.TensorLike, offdiag: pt.TensorLike
-) -> pt.TensorLike:
+def construct_square_matrix(n: int, diagonal, offdiag):
     """Constructs a square matrix from the diagonal and off-diagonal elements.
 
     Args:

--- a/src/pmhn/_ppl/_priors.py
+++ b/src/pmhn/_ppl/_priors.py
@@ -306,12 +306,12 @@ def prior_spike_and_slab_marginalized(
     with pm.Model() as model:
         gamma = pm.Beta("sparsity", sparsity_a, sparsity_b)
         offdiag_sigmas = pm.HalfNormal(
-            "offdiag_sigmas", pt.as_tensor([spike_scale, slab_scale])  # type: ignore
+            "offdiag_sigmas", pt.stack([spike_scale, slab_scale])  # type: ignore
         )
         offdiag_entries = pm.NormalMixture(
             "offdiag_entries",
             mu=0,
-            w=pt.stack([gamma, 1.0 - gamma]),
+            w=pt.stack([gamma, 1.0 - gamma]),  # type: ignore
             sigma=offdiag_sigmas,
             shape=_offdiag_size(n_mutations),
         )

--- a/src/pmhn/_ppl/_priors.py
+++ b/src/pmhn/_ppl/_priors.py
@@ -306,7 +306,7 @@ def prior_spike_and_slab_marginalized(
     with pm.Model() as model:
         gamma = pm.Beta("sparsity", sparsity_a, sparsity_b)
         offdiag_sigmas = pm.HalfNormal(
-            "offdiag_sigmas", pt.stack([spike_scale, slab_scale])  # type: ignore
+            "offdiag_sigmas", pt.stack([spike_scale, slab_scale])  # pyright: ignore
         )
         offdiag_entries = pm.NormalMixture(
             "offdiag_entries",

--- a/src/pmhn/_ppl/_priors.py
+++ b/src/pmhn/_ppl/_priors.py
@@ -306,7 +306,7 @@ def prior_spike_and_slab_marginalized(
     with pm.Model() as model:
         gamma = pm.Beta("sparsity", sparsity_a, sparsity_b)
         offdiag_sigmas = pm.HalfNormal(
-            "offdiag_sigmas", pt.as_tensor([spike_scale, slab_scale])
+            "offdiag_sigmas", pt.as_tensor([spike_scale, slab_scale])  # type: ignore
         )
         offdiag_entries = pm.NormalMixture(
             "offdiag_entries",

--- a/src/pmhn/_ppl/_treemhn.py
+++ b/src/pmhn/_ppl/_treemhn.py
@@ -44,7 +44,7 @@ class TreeMHNLoglikelihood(Op):
             sampling_rate=1.0 / self._mean_sampling_time,
             all_mut=self._all_mut,
         )
-        total_loglikelihood = np.sum(loglikelihoods)
+        total_loglikelihood = np.sum(loglikelihoods)  # type: ignore
         outputs[0][0] = np.array(
             total_loglikelihood
         )  # Wrap the log-likelihood into output

--- a/tests/ppl/test_priors.py
+++ b/tests/ppl/test_priors.py
@@ -12,6 +12,7 @@ import pmhn._ppl._priors as priors
         priors.prior_regularized_horseshoe,
         priors.prior_offdiagonal_laplace,
         priors.prior_horseshoe,
+        priors.prior_spike_and_slab_marginalized,
     ],
 )
 def test_basic_prior_test(model_factory, n_mutations: int = 5) -> None:

--- a/tests/ppl/test_priors.py
+++ b/tests/ppl/test_priors.py
@@ -11,6 +11,7 @@ import pmhn._ppl._priors as priors
         priors.prior_normal,
         priors.prior_regularized_horseshoe,
         priors.prior_offdiagonal_laplace,
+        priors.prior_horseshoe,
     ],
 )
 def test_basic_prior_test(model_factory, n_mutations: int = 5) -> None:


### PR DESCRIPTION
This PR adds new priors and refactors old ones. Although the API is still compatible, the meaning of hyperparameters is now a bit different (as they explicitly control the off-diagonal terms).

The changes include:
- [x] More explicit control over the sparsity of the off-diagonal terms.
- [x] Marginalized Gaussian spike-and-slab.
- [x] Horseshoe prior.