### PR TITLE
Ragged tree backend

### DIFF
--- a/src/pmhn/_trees/_backend_jax/__init__.py
+++ b/src/pmhn/_trees/_backend_jax/__init__.py
@@ -1,20 +1,64 @@
-from pmhn._trees._backend_jax._loglikelihood import loglikelihood
+"""JAX backend for tree likelihoods.
+
+Default exports are ragged-first (no path padding).
+Legacy padded API remains available via `legacy_*` names.
+"""
+
+from pmhn._trees._backend_jax._loglikelihood import (
+    loglikelihood as legacy_loglikelihood,
+)
 from pmhn._trees._backend_jax._sparse import COOMatrix, Values
 from pmhn._trees._backend_jax._wrapper import (
-    DoublyIndexedPaths,
-    ExitPathsArray,
-    IndexedPaths,
-    WrappedTree,
-    wrap_tree,
+    DoublyIndexedPaths as LegacyDoublyIndexedPaths,
+)
+from pmhn._trees._backend_jax._wrapper import ExitPathsArray as LegacyExitPathsArray
+from pmhn._trees._backend_jax._wrapper import IndexedPaths as LegacyIndexedPaths
+from pmhn._trees._backend_jax._wrapper import WrappedTree as LegacyWrappedTree
+from pmhn._trees._backend_jax._wrapper import wrap_tree as legacy_wrap_tree
+from pmhn._trees._backend_jax_ragged import (
+    BilinearLogRateModel,
+    MLPLogRateModel,
+    RaggedPaths,
+    RaggedTree,
+    loglikelihood,
+    loglikelihood_many,
+    loglikelihood_many_with_rate_model,
+    loglikelihood_with_rate_model,
+    logprob_forward_substitution_layerwise,
+    wrap_tree_ragged,
 )
 
+# Default migration aliases.
+WrappedTree = RaggedTree
+wrap_tree = wrap_tree_ragged
+IndexedPaths = LegacyIndexedPaths
+DoublyIndexedPaths = LegacyDoublyIndexedPaths
+ExitPathsArray = LegacyExitPathsArray
+
 __all__ = [
+    # Default ragged API
+    "RaggedPaths",
+    "RaggedTree",
     "WrappedTree",
     "wrap_tree",
-    "IndexedPaths",
-    "DoublyIndexedPaths",
-    "ExitPathsArray",
     "COOMatrix",
     "Values",
     "loglikelihood",
+    "loglikelihood_many",
+    "loglikelihood_with_rate_model",
+    "loglikelihood_many_with_rate_model",
+    "logprob_forward_substitution_layerwise",
+    "BilinearLogRateModel",
+    "MLPLogRateModel",
+    # Legacy compatibility API
+    "LegacyWrappedTree",
+    "LegacyIndexedPaths",
+    "LegacyDoublyIndexedPaths",
+    "LegacyExitPathsArray",
+    "legacy_wrap_tree",
+    "legacy_loglikelihood",
+    # Kept names for compatibility with existing type imports
+    "IndexedPaths",
+    "DoublyIndexedPaths",
+    "ExitPathsArray",
 ]

--- a/src/pmhn/_trees/_backend_jax_ragged/__init__.py
+++ b/src/pmhn/_trees/_backend_jax_ragged/__init__.py
@@ -1,6 +1,12 @@
 from pmhn._trees._backend_jax_ragged._loglikelihood import (
     loglikelihood,
     loglikelihood_many,
+    loglikelihood_many_with_rate_model,
+    loglikelihood_with_rate_model,
+)
+from pmhn._trees._backend_jax_ragged._models import (
+    BilinearLogRateModel,
+    MLPLogRateModel,
 )
 from pmhn._trees._backend_jax_ragged._solver import (
     logprob_forward_substitution_layerwise,
@@ -17,5 +23,9 @@ __all__ = [
     "wrap_tree_ragged",
     "loglikelihood",
     "loglikelihood_many",
+    "loglikelihood_with_rate_model",
+    "loglikelihood_many_with_rate_model",
+    "BilinearLogRateModel",
+    "MLPLogRateModel",
     "logprob_forward_substitution_layerwise",
 ]

--- a/src/pmhn/_trees/_backend_jax_ragged/__init__.py
+++ b/src/pmhn/_trees/_backend_jax_ragged/__init__.py
@@ -2,6 +2,9 @@ from pmhn._trees._backend_jax_ragged._loglikelihood import (
     loglikelihood,
     loglikelihood_many,
 )
+from pmhn._trees._backend_jax_ragged._solver import (
+    logprob_forward_substitution_layerwise,
+)
 from pmhn._trees._backend_jax_ragged._wrapper import (
     RaggedPaths,
     RaggedTree,
@@ -14,4 +17,5 @@ __all__ = [
     "wrap_tree_ragged",
     "loglikelihood",
     "loglikelihood_many",
+    "logprob_forward_substitution_layerwise",
 ]

--- a/src/pmhn/_trees/_backend_jax_ragged/__init__.py
+++ b/src/pmhn/_trees/_backend_jax_ragged/__init__.py
@@ -1,0 +1,11 @@
+from pmhn._trees._backend_jax_ragged._wrapper import (
+    RaggedPaths,
+    RaggedTree,
+    wrap_tree_ragged,
+)
+
+__all__ = [
+    "RaggedPaths",
+    "RaggedTree",
+    "wrap_tree_ragged",
+]

--- a/src/pmhn/_trees/_backend_jax_ragged/__init__.py
+++ b/src/pmhn/_trees/_backend_jax_ragged/__init__.py
@@ -1,3 +1,7 @@
+from pmhn._trees._backend_jax_ragged._loglikelihood import (
+    loglikelihood,
+    loglikelihood_many,
+)
 from pmhn._trees._backend_jax_ragged._wrapper import (
     RaggedPaths,
     RaggedTree,
@@ -8,4 +12,6 @@ __all__ = [
     "RaggedPaths",
     "RaggedTree",
     "wrap_tree_ragged",
+    "loglikelihood",
+    "loglikelihood_many",
 ]

--- a/src/pmhn/_trees/_backend_jax_ragged/_loglikelihood.py
+++ b/src/pmhn/_trees/_backend_jax_ragged/_loglikelihood.py
@@ -1,8 +1,10 @@
 import jax.numpy as jnp
 from jaxtyping import Array, Float
 
-from pmhn._trees._backend_jax._solver import logprob_forward_substitution
 from pmhn._trees._backend_jax_ragged._rates import _construct_log_magic_matrix
+from pmhn._trees._backend_jax_ragged._solver import (
+    logprob_forward_substitution_layerwise,
+)
 from pmhn._trees._backend_jax_ragged._wrapper import RaggedTree
 
 
@@ -18,7 +20,11 @@ def loglikelihood(
         omega=omega,
         log_tau=log_tau,
     )
-    log_probs = logprob_forward_substitution(log_magic)
+    log_probs = logprob_forward_substitution_layerwise(
+        log_magic=log_magic,
+        node_layer=tree.node_layer,
+        layer_ptr=tree.layer_ptr,
+    )
     return log_probs[-1]
 
 

--- a/src/pmhn/_trees/_backend_jax_ragged/_loglikelihood.py
+++ b/src/pmhn/_trees/_backend_jax_ragged/_loglikelihood.py
@@ -1,7 +1,12 @@
-import jax.numpy as jnp
-from jaxtyping import Array, Float
+from collections.abc import Callable
 
-from pmhn._trees._backend_jax_ragged._rates import _construct_log_magic_matrix
+import jax.numpy as jnp
+from jaxtyping import Array, Float, Int
+
+from pmhn._trees._backend_jax_ragged._rates import (
+    _construct_log_magic_matrix,
+    _construct_log_magic_matrix_with_rate_model,
+)
 from pmhn._trees._backend_jax_ragged._solver import (
     logprob_forward_substitution_layerwise,
 )
@@ -41,3 +46,39 @@ def loglikelihood_many(
         over trees is the intended baseline pattern.
     """
     return jnp.asarray([loglikelihood(theta, omega, tree, log_tau) for tree in trees])
+
+
+def loglikelihood_with_rate_model(
+    log_rate_model: Callable[[Float[Array, " G"], Int[Array, ""]], Float],
+    omega: Float[Array, " G"],
+    tree: RaggedTree,
+    log_tau: float | Float = 0.0,
+) -> Float:
+    """Likelihood using a generic log-rate model instead of bilinear theta."""
+    log_magic = _construct_log_magic_matrix_with_rate_model(
+        tree=tree,
+        omega=omega,
+        log_tau=log_tau,
+        log_rate_model=log_rate_model,
+    )
+    log_probs = logprob_forward_substitution_layerwise(
+        log_magic=log_magic,
+        node_layer=tree.node_layer,
+        layer_ptr=tree.layer_ptr,
+    )
+    return log_probs[-1]
+
+
+def loglikelihood_many_with_rate_model(
+    log_rate_model: Callable[[Float[Array, " G"], Int[Array, ""]], Float],
+    omega: Float[Array, " G"],
+    trees: list[RaggedTree],
+    log_tau: float | Float = 0.0,
+) -> Float[Array, " n_trees"]:
+    """Evaluates model-based likelihood on a heterogeneous list of wrapped trees."""
+    return jnp.asarray(
+        [
+            loglikelihood_with_rate_model(log_rate_model, omega, tree, log_tau)
+            for tree in trees
+        ]
+    )

--- a/src/pmhn/_trees/_backend_jax_ragged/_loglikelihood.py
+++ b/src/pmhn/_trees/_backend_jax_ragged/_loglikelihood.py
@@ -1,0 +1,37 @@
+import jax.numpy as jnp
+from jaxtyping import Array, Float
+
+from pmhn._trees._backend_jax._solver import logprob_forward_substitution
+from pmhn._trees._backend_jax_ragged._rates import _construct_log_magic_matrix
+from pmhn._trees._backend_jax_ragged._wrapper import RaggedTree
+
+
+def loglikelihood(
+    theta: Float[Array, "G G"],
+    omega: Float[Array, " G"],
+    tree: RaggedTree,
+    log_tau: float | Float = 0.0,
+) -> Float:
+    log_magic = _construct_log_magic_matrix(
+        tree=tree,
+        theta=theta,
+        omega=omega,
+        log_tau=log_tau,
+    )
+    log_probs = logprob_forward_substitution(log_magic)
+    return log_probs[-1]
+
+
+def loglikelihood_many(
+    theta: Float[Array, "G G"],
+    omega: Float[Array, " G"],
+    trees: list[RaggedTree],
+    log_tau: float | Float = 0.0,
+) -> Float[Array, " n_trees"]:
+    """Evaluates likelihood on a heterogeneous list of wrapped trees.
+
+    Note:
+        Trees with different sizes/shapes cannot be vmap'ed directly. A Python loop
+        over trees is the intended baseline pattern.
+    """
+    return jnp.asarray([loglikelihood(theta, omega, tree, log_tau) for tree in trees])

--- a/src/pmhn/_trees/_backend_jax_ragged/_models.py
+++ b/src/pmhn/_trees/_backend_jax_ragged/_models.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+try:
+    import equinox as eqx
+except ModuleNotFoundError:  # pragma: no cover - exercised only when missing dep
+    eqx = None
+
+
+if eqx is not None:
+
+    class BilinearLogRateModel(eqx.Module):
+        """Bilinear model in the same functional form as the original backend."""
+
+        theta: jax.Array
+
+        def __call__(
+            self, lineage_multihot: jax.Array, new_mut: jax.Array
+        ) -> jax.Array:
+            # new_mut is 1-indexed.
+            return jnp.sum(self.theta[new_mut - 1] * lineage_multihot)
+
+    class MLPLogRateModel(eqx.Module):
+        """Simple Equinox MLP model for generic log-rates."""
+
+        mlp: eqx.nn.MLP
+        n_genes: int = eqx.field(static=True)
+
+        def __init__(
+            self,
+            n_genes: int,
+            key: jax.Array,
+            width_size: int = 64,
+            depth: int = 2,
+        ) -> None:
+            self.n_genes = n_genes
+            self.mlp = eqx.nn.MLP(
+                in_size=2 * n_genes,
+                out_size=1,
+                width_size=width_size,
+                depth=depth,
+                activation=jax.nn.tanh,
+                final_activation=lambda x: x,
+                key=key,
+            )
+
+        def __call__(
+            self, lineage_multihot: jax.Array, new_mut: jax.Array
+        ) -> jax.Array:
+            # new_mut is 1-indexed.
+            new_mut_onehot = jax.nn.one_hot(
+                new_mut - 1, self.n_genes, dtype=jnp.float32
+            )
+            features = jnp.concatenate(
+                [lineage_multihot.astype(jnp.float32), new_mut_onehot],
+                axis=-1,
+            )
+            return jnp.squeeze(self.mlp(features), axis=-1)
+
+else:
+
+    class BilinearLogRateModel:  # pragma: no cover - exercised only when missing dep
+        def __init__(self, *args, **kwargs) -> None:
+            raise ModuleNotFoundError(
+                "equinox is required to use BilinearLogRateModel. "
+                "Install equinox or use the bilinear theta backend."
+            )
+
+    class MLPLogRateModel:  # pragma: no cover - exercised only when missing dep
+        def __init__(self, *args, **kwargs) -> None:
+            raise ModuleNotFoundError(
+                "equinox is required to use MLPLogRateModel. "
+                "Install equinox and retry."
+            )

--- a/src/pmhn/_trees/_backend_jax_ragged/_rates.py
+++ b/src/pmhn/_trees/_backend_jax_ragged/_rates.py
@@ -1,0 +1,128 @@
+"""Rate construction for ragged tree representation."""
+
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, Float, Int
+
+from pmhn._trees._backend_jax._sparse import COOMatrix, Values
+from pmhn._trees._backend_jax_ragged._wrapper import RaggedPaths, RaggedTree
+
+
+def segment_logsumexp(
+    data: Float[Array, " n"],
+    segment_ids: Int[Array, " n"],
+    num_segments: int,
+) -> Float[Array, " num_segments"]:
+    """Segment-wise logsumexp."""
+    max_per_segment = jax.ops.segment_max(
+        data, segment_ids=segment_ids, num_segments=num_segments
+    )
+    adjusted_values = jnp.exp(data - max_per_segment[segment_ids])
+    summed_exp_values = jax.ops.segment_sum(
+        adjusted_values, segment_ids=segment_ids, num_segments=num_segments
+    )
+    return jnp.log(summed_exp_values) + max_per_segment
+
+
+def _construct_path_log_transition_rates(
+    paths: RaggedPaths,
+    theta: Float[Array, "G G"],
+) -> Float[Array, " n_paths"]:
+    """Computes transition log-rates for all paths."""
+    path_ids = paths.event_path_id
+    new_mut = paths.path_last_event[path_ids]
+    event_mut = paths.events_flat
+
+    per_event = theta[new_mut - 1, event_mut - 1]
+    return jax.ops.segment_sum(
+        per_event, segment_ids=path_ids, num_segments=paths.n_paths
+    )
+
+
+def _construct_path_log_exit_rates(
+    paths: RaggedPaths,
+    omega: Float[Array, " G"],
+) -> Float[Array, " n_paths"]:
+    """Computes exit log-rates for all paths."""
+    path_ids = paths.event_path_id
+    per_event = omega[paths.events_flat - 1]
+    return jax.ops.segment_sum(
+        per_event, segment_ids=path_ids, num_segments=paths.n_paths
+    )
+
+
+def _construct_log_Q_offdiag(
+    tree: RaggedTree,
+    path_log_transition_rates: Float[Array, " n_paths"],
+) -> Values:
+    return Values(
+        start=tree.edge_start,
+        end=tree.edge_end,
+        value=path_log_transition_rates[tree.edge_path_id],
+    )
+
+
+def _construct_log_neg_Q_diag(
+    tree: RaggedTree,
+    path_log_transition_rates: Float[Array, " n_paths"],
+) -> Float[Array, " n_subtrees"]:
+    return segment_logsumexp(
+        path_log_transition_rates[tree.diag_path_id],
+        segment_ids=tree.diag_subtree_id,
+        num_segments=tree.n_subtrees,
+    )
+
+
+def _construct_log_U(
+    tree: RaggedTree,
+    path_log_exit_rates: Float[Array, " n_paths"],
+    log_tau: float | Float,
+) -> Float[Array, " n_subtrees"]:
+    # For parity with the current padded backend implementation, use the same
+    # placeholder exit behavior: every subtree gets log_U = -log_tau.
+    _ = path_log_exit_rates
+    return jnp.full((tree.n_subtrees,), fill_value=-log_tau)
+
+
+def _log_neg_Q_to_log_V(
+    log_neg_Q: Float[Array, " n_subtrees"],
+) -> Float[Array, " n_subtrees"]:
+    return jax.nn.softplus(log_neg_Q)
+
+
+def _construct_log_magic_matrix(
+    tree: RaggedTree,
+    theta: Float[Array, "G G"],
+    omega: Float[Array, " G"],
+    log_tau: float | Float,
+) -> COOMatrix:
+    """Constructs log-magic matrix from ragged tree representation."""
+    path_log_transition_rates = _construct_path_log_transition_rates(
+        paths=tree.paths, theta=theta
+    )
+    path_log_exit_rates = _construct_path_log_exit_rates(paths=tree.paths, omega=omega)
+
+    log_neg_Q_diag = _construct_log_neg_Q_diag(
+        tree=tree, path_log_transition_rates=path_log_transition_rates
+    )
+    log_Q_offdiag = _construct_log_Q_offdiag(
+        tree=tree, path_log_transition_rates=path_log_transition_rates
+    )
+    log_U = _construct_log_U(
+        tree=tree,
+        path_log_exit_rates=path_log_exit_rates,
+        log_tau=log_tau,
+    )
+
+    log_neg_Q_diag_adjusted = log_neg_Q_diag - log_U
+    log_Q_offdiag_adjusted = Values(
+        start=log_Q_offdiag.start,
+        end=log_Q_offdiag.end,
+        value=log_Q_offdiag.value - log_U[log_Q_offdiag.start],
+    )
+
+    return COOMatrix(
+        diagonal=_log_neg_Q_to_log_V(log_neg_Q_diag_adjusted),
+        offdiagonal=log_Q_offdiag_adjusted,
+        fill_value=-jnp.inf,
+    )

--- a/src/pmhn/_trees/_backend_jax_ragged/_rates.py
+++ b/src/pmhn/_trees/_backend_jax_ragged/_rates.py
@@ -1,5 +1,7 @@
 """Rate construction for ragged tree representation."""
 
+from collections.abc import Callable
+
 import jax
 import jax.numpy as jnp
 from jaxtyping import Array, Float, Int
@@ -44,6 +46,29 @@ def _construct_path_log_transition_rates(
     return jax.ops.segment_sum(
         per_event, segment_ids=path_ids, num_segments=paths.n_paths
     )
+
+
+def _construct_path_lineage_multihot(
+    paths: RaggedPaths,
+    n_genes: int,
+) -> Float[Array, " n_paths G"]:
+    event_one_hot = jax.nn.one_hot(paths.events_flat - 1, n_genes, dtype=jnp.float32)
+    counts = jax.ops.segment_sum(
+        event_one_hot,
+        segment_ids=paths.event_path_id,
+        num_segments=paths.n_paths,
+    )
+    return jnp.clip(counts, 0.0, 1.0)
+
+
+def _construct_path_log_transition_rates_model(
+    paths: RaggedPaths,
+    n_genes: int,
+    log_rate_model: Callable[[Float[Array, " G"], Int[Array, ""]], Float],
+) -> Float[Array, " n_paths"]:
+    """Computes transition log-rates for all paths using a generic model."""
+    lineage_multihot = _construct_path_lineage_multihot(paths=paths, n_genes=n_genes)
+    return jax.vmap(log_rate_model)(lineage_multihot, paths.path_last_event)
 
 
 def _construct_path_log_exit_rates(
@@ -106,6 +131,46 @@ def _construct_log_magic_matrix(
     """Constructs log-magic matrix from ragged tree representation."""
     path_log_transition_rates = _construct_path_log_transition_rates(
         paths=tree.paths, theta=theta
+    )
+    path_log_exit_rates = _construct_path_log_exit_rates(paths=tree.paths, omega=omega)
+
+    log_neg_Q_diag = _construct_log_neg_Q_diag(
+        tree=tree, path_log_transition_rates=path_log_transition_rates
+    )
+    log_Q_offdiag = _construct_log_Q_offdiag(
+        tree=tree, path_log_transition_rates=path_log_transition_rates
+    )
+    log_U = _construct_log_U(
+        tree=tree,
+        path_log_exit_rates=path_log_exit_rates,
+        log_tau=log_tau,
+    )
+
+    log_neg_Q_diag_adjusted = log_neg_Q_diag - log_U
+    log_Q_offdiag_adjusted = Values(
+        start=log_Q_offdiag.start,
+        end=log_Q_offdiag.end,
+        value=log_Q_offdiag.value - log_U[log_Q_offdiag.start],
+    )
+
+    return COOMatrix(
+        diagonal=_log_neg_Q_to_log_V(log_neg_Q_diag_adjusted),
+        offdiagonal=log_Q_offdiag_adjusted,
+        fill_value=-jnp.inf,
+    )
+
+
+def _construct_log_magic_matrix_with_rate_model(
+    tree: RaggedTree,
+    omega: Float[Array, " G"],
+    log_tau: float | Float,
+    log_rate_model: Callable[[Float[Array, " G"], Int[Array, ""]], Float],
+) -> COOMatrix:
+    """Constructs log-magic matrix from a generic log-rate model."""
+    path_log_transition_rates = _construct_path_log_transition_rates_model(
+        paths=tree.paths,
+        n_genes=tree.n_genes,
+        log_rate_model=log_rate_model,
     )
     path_log_exit_rates = _construct_path_log_exit_rates(paths=tree.paths, omega=omega)
 

--- a/src/pmhn/_trees/_backend_jax_ragged/_rates.py
+++ b/src/pmhn/_trees/_backend_jax_ragged/_rates.py
@@ -13,15 +13,22 @@ def segment_logsumexp(
     segment_ids: Int[Array, " n"],
     num_segments: int,
 ) -> Float[Array, " num_segments"]:
-    """Segment-wise logsumexp."""
+    """Segment-wise logsumexp robust to all--inf or empty segments."""
     max_per_segment = jax.ops.segment_max(
         data, segment_ids=segment_ids, num_segments=num_segments
     )
-    adjusted_values = jnp.exp(data - max_per_segment[segment_ids])
+
+    finite_mask = jnp.isfinite(max_per_segment)
+    safe_max_per_segment = jnp.where(finite_mask, max_per_segment, 0.0)
+
+    adjusted_values = jnp.exp(data - safe_max_per_segment[segment_ids])
+    adjusted_values = jnp.where(jnp.isfinite(data), adjusted_values, 0.0)
+
     summed_exp_values = jax.ops.segment_sum(
         adjusted_values, segment_ids=segment_ids, num_segments=num_segments
     )
-    return jnp.log(summed_exp_values) + max_per_segment
+    out = jnp.log(summed_exp_values) + safe_max_per_segment
+    return jnp.where(finite_mask, out, -jnp.inf)
 
 
 def _construct_path_log_transition_rates(

--- a/src/pmhn/_trees/_backend_jax_ragged/_solver.py
+++ b/src/pmhn/_trees/_backend_jax_ragged/_solver.py
@@ -1,0 +1,73 @@
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, Float, Int
+
+from pmhn._trees._backend_jax._sparse import COOMatrix
+
+
+def _segment_logsumexp_safe(
+    data: Float[Array, " n"],
+    segment_ids: Int[Array, " n"],
+    num_segments: int,
+) -> Float[Array, " num_segments"]:
+    """Segment-wise logsumexp robust to all--inf segments."""
+    max_per_segment = jax.ops.segment_max(
+        data, segment_ids=segment_ids, num_segments=num_segments
+    )
+    finite_mask = jnp.isfinite(max_per_segment)
+    safe_max_per_segment = jnp.where(finite_mask, max_per_segment, 0.0)
+
+    adjusted = jnp.exp(data - safe_max_per_segment[segment_ids])
+    adjusted = jnp.where(jnp.isfinite(data), adjusted, 0.0)
+
+    summed = jax.ops.segment_sum(
+        adjusted, segment_ids=segment_ids, num_segments=num_segments
+    )
+
+    out = jnp.log(summed) + safe_max_per_segment
+    return jnp.where(finite_mask, out, -jnp.inf)
+
+
+def logprob_forward_substitution_layerwise(
+    log_magic: COOMatrix,
+    node_layer: Int[Array, " S"],
+    layer_ptr: Int[Array, " Lp1"],
+) -> Float[Array, " S"]:
+    """Layer-parallel forward substitution in log-space.
+
+    Note:
+        This assumes subtree indices are grouped by layer and `node_layer`
+        is aligned with matrix indices.
+    """
+    size = log_magic.size
+    n_layers = layer_ptr.shape[0] - 1
+
+    log_x0 = jnp.full(size, fill_value=-jnp.inf).at[0].set(-log_magic.diagonal[0])
+
+    if n_layers <= 1:
+        return log_x0
+
+    def single_layer(logx, layer):
+        # Gather contributions into nodes in the selected layer.
+        edge_end_layer = node_layer[log_magic.offdiagonal.end]
+        active_edge = edge_end_layer == layer
+        log_contrib = jnp.where(
+            active_edge,
+            log_magic.offdiagonal.value + logx[log_magic.offdiagonal.start],
+            -jnp.inf,
+        )
+
+        incoming = _segment_logsumexp_safe(
+            log_contrib,
+            segment_ids=log_magic.offdiagonal.end,
+            num_segments=size,
+        )
+        updates = incoming - log_magic.diagonal
+
+        target_nodes = node_layer == layer
+        new_logx = jnp.where(target_nodes, updates, logx)
+        return new_logx, None
+
+    layers = jnp.arange(1, n_layers, dtype=int)
+    log_x, _ = jax.lax.scan(single_layer, log_x0, layers)
+    return log_x

--- a/src/pmhn/_trees/_backend_jax_ragged/_wrapper.py
+++ b/src/pmhn/_trees/_backend_jax_ragged/_wrapper.py
@@ -14,6 +14,7 @@ class RaggedPaths(NamedTuple):
     """Ragged representation of a collection of mutation trajectories."""
 
     events_flat: Int[Array, " n_events"]
+    event_path_id: Int[Array, " n_events"]
     path_ptr: Int[Array, " n_paths_plus_one"]
     path_last_event: Int[Array, " n_paths"]
 
@@ -136,6 +137,16 @@ def wrap_tree_ragged(tree: Node, n_genes: int) -> tuple[RaggedTree, list[Node]]:
     wrapped = RaggedTree(
         paths=RaggedPaths(
             events_flat=jnp.asarray(events_flat, dtype=int),
+            event_path_id=jnp.asarray(
+                [
+                    path_id
+                    for path_id, (start, end) in enumerate(
+                        zip(path_ptr[:-1], path_ptr[1:])
+                    )
+                    for _ in range(end - start)
+                ],
+                dtype=int,
+            ),
             path_ptr=jnp.asarray(path_ptr, dtype=int),
             path_last_event=jnp.asarray(path_last_event, dtype=int),
         ),

--- a/src/pmhn/_trees/_backend_jax_ragged/_wrapper.py
+++ b/src/pmhn/_trees/_backend_jax_ragged/_wrapper.py
@@ -1,0 +1,154 @@
+from collections.abc import Iterable
+from typing import NamedTuple
+
+import jax.numpy as jnp
+from anytree import Node
+from jaxtyping import Array, Int
+
+from pmhn._trees._tree_utils import construct_paths_matrix
+
+_RawTrajectory = tuple[int, ...] | list[int]
+
+
+class RaggedPaths(NamedTuple):
+    """Ragged representation of a collection of mutation trajectories."""
+
+    events_flat: Int[Array, " n_events"]
+    path_ptr: Int[Array, " n_paths_plus_one"]
+    path_last_event: Int[Array, " n_paths"]
+
+    @property
+    def n_paths(self) -> int:
+        return self.path_ptr.shape[0] - 1
+
+
+class RaggedTree(NamedTuple):
+    """Ragged tree wrapper used by the JAX backend."""
+
+    paths: RaggedPaths
+    edge_start: Int[Array, " n_edges"]
+    edge_end: Int[Array, " n_edges"]
+    edge_path_id: Int[Array, " n_edges"]
+    diag_subtree_id: Int[Array, " n_diag"]
+    diag_path_id: Int[Array, " n_diag"]
+    exit_subtree_id: Int[Array, " n_exit"]
+    exit_path_id: Int[Array, " n_exit"]
+    node_layer: Int[Array, " n_subtrees"]
+    layer_ptr: Int[Array, " n_layers_plus_one"]
+    n_genes: int
+
+    @property
+    def n_subtrees(self) -> int:
+        return self.node_layer.shape[0]
+
+    @property
+    def n_layers(self) -> int:
+        return self.layer_ptr.shape[0] - 1
+
+
+def _strip_root(traj: _RawTrajectory) -> tuple[int, ...]:
+    stripped = tuple(traj)[1:]
+    if len(stripped) == 0:
+        raise ValueError(
+            "Encountered an empty trajectory after removing root. "
+            "All encoded trajectories must include at least one mutation."
+        )
+    return stripped
+
+
+def _layer_ptr_from_layers(node_layer: list[int]) -> list[int]:
+    if len(node_layer) == 0:
+        return [0]
+
+    max_layer = max(node_layer)
+    counts = [0 for _ in range(max_layer + 1)]
+
+    for layer_idx in node_layer:
+        if layer_idx < 0:
+            raise ValueError(f"Layer index has to be non-negative, got {layer_idx}.")
+        counts[layer_idx] += 1
+
+    layer_ptr = [0]
+    running = 0
+    for c in counts:
+        running += c
+        layer_ptr.append(running)
+    return layer_ptr
+
+
+def _iterate_diag_paths(
+    diag_paths: list[list[_RawTrajectory]],
+) -> Iterable[tuple[int, tuple[int, ...]]]:
+    for subtree_id, traj_list in enumerate(diag_paths):
+        for traj in sorted(map(tuple, traj_list)):
+            yield subtree_id, _strip_root(traj)
+
+
+def wrap_tree_ragged(tree: Node, n_genes: int) -> tuple[RaggedTree, list[Node]]:
+    """Wraps a tree into a ragged representation with no path padding."""
+    paths_object = construct_paths_matrix(tree, n_genes=n_genes)
+
+    path_to_id: dict[tuple[int, ...], int] = {}
+    events_flat: list[int] = []
+    path_ptr: list[int] = [0]
+    path_last_event: list[int] = []
+
+    def get_path_id(traj: tuple[int, ...]) -> int:
+        pid = path_to_id.get(traj)
+        if pid is not None:
+            return pid
+
+        pid = len(path_to_id)
+        path_to_id[traj] = pid
+        events_flat.extend(traj)
+        path_ptr.append(len(events_flat))
+        path_last_event.append(traj[-1])
+        return pid
+
+    edge_start: list[int] = []
+    edge_end: list[int] = []
+    edge_path_id: list[int] = []
+
+    for (start, end), traj in sorted(paths_object.offdiag.items()):
+        if start >= end:
+            raise ValueError(f"Expected start < end, got ({start}, {end}).")
+        traj_wo_root = _strip_root(traj)
+        edge_start.append(start)
+        edge_end.append(end)
+        edge_path_id.append(get_path_id(traj_wo_root))
+
+    diag_subtree_id: list[int] = []
+    diag_path_id: list[int] = []
+
+    for subtree_id, traj in _iterate_diag_paths(paths_object.diag):
+        diag_subtree_id.append(subtree_id)
+        diag_path_id.append(get_path_id(traj))
+
+    # Exit terms mirror the diagonal path specification.
+    exit_subtree_id = list(diag_subtree_id)
+    exit_path_id = list(diag_path_id)
+
+    node_layer = [subtree.size - 1 for subtree in paths_object.indices]
+    if any(node_layer[i] > node_layer[i + 1] for i in range(len(node_layer) - 1)):
+        raise ValueError("Subtrees are expected to be sorted by non-decreasing size.")
+    layer_ptr = _layer_ptr_from_layers(node_layer)
+
+    wrapped = RaggedTree(
+        paths=RaggedPaths(
+            events_flat=jnp.asarray(events_flat, dtype=int),
+            path_ptr=jnp.asarray(path_ptr, dtype=int),
+            path_last_event=jnp.asarray(path_last_event, dtype=int),
+        ),
+        edge_start=jnp.asarray(edge_start, dtype=int),
+        edge_end=jnp.asarray(edge_end, dtype=int),
+        edge_path_id=jnp.asarray(edge_path_id, dtype=int),
+        diag_subtree_id=jnp.asarray(diag_subtree_id, dtype=int),
+        diag_path_id=jnp.asarray(diag_path_id, dtype=int),
+        exit_subtree_id=jnp.asarray(exit_subtree_id, dtype=int),
+        exit_path_id=jnp.asarray(exit_path_id, dtype=int),
+        node_layer=jnp.asarray(node_layer, dtype=int),
+        layer_ptr=jnp.asarray(layer_ptr, dtype=int),
+        n_genes=n_genes,
+    )
+
+    return wrapped, paths_object.indices

--- a/tests/trees/backend_jax/test_public_api_migration.py
+++ b/tests/trees/backend_jax/test_public_api_migration.py
@@ -1,0 +1,59 @@
+import jax.numpy as jnp
+import numpy as np
+import numpy.testing as npt
+import pmhn._trees._backend_jax as backend_default
+import pmhn._trees._backend_jax_ragged as backend_ragged
+from anytree import Node
+
+
+def _build_tree() -> Node:
+    root = Node(0)
+    left = Node(1, parent=root)
+    Node(2, parent=root)
+    Node(3, parent=left)
+    return root
+
+
+def test_default_backend_jax_wrap_tree_is_ragged() -> None:
+    wrapped, _ = backend_default.wrap_tree(_build_tree(), n_genes=5)
+    assert isinstance(wrapped, backend_ragged.RaggedTree)
+    assert hasattr(wrapped.paths, "event_path_id")
+
+
+def test_default_backend_jax_loglikelihood_matches_ragged(seed: int = 1) -> None:
+    tree = _build_tree()
+    wrapped_default, _ = backend_default.wrap_tree(tree, n_genes=5)
+    wrapped_ragged, _ = backend_ragged.wrap_tree_ragged(tree, n_genes=5)
+
+    rng = np.random.default_rng(seed)
+    theta = jnp.asarray(rng.normal(size=(5, 5)))
+    omega = jnp.asarray(rng.normal(size=(5,)))
+    log_tau = -0.23
+
+    val_default = backend_default.loglikelihood(
+        theta=theta, omega=omega, tree=wrapped_default, log_tau=log_tau
+    )
+    val_ragged = backend_ragged.loglikelihood(
+        theta=theta, omega=omega, tree=wrapped_ragged, log_tau=log_tau
+    )
+    npt.assert_allclose(val_default, val_ragged, atol=1e-6)
+
+
+def test_legacy_backend_jax_api_still_available(seed: int = 3) -> None:
+    tree = _build_tree()
+    wrapped_legacy, _ = backend_default.legacy_wrap_tree(tree, n_genes=5)
+    wrapped_default, _ = backend_default.wrap_tree(tree, n_genes=5)
+
+    # Legacy wrapper keeps padded-path structure.
+    assert hasattr(wrapped_legacy, "diag_paths")
+    assert not hasattr(wrapped_default, "diag_paths")
+
+    rng = np.random.default_rng(seed)
+    theta = jnp.asarray(rng.normal(size=(5, 5)))
+    omega = jnp.asarray(rng.normal(size=(5,)))
+    log_tau = 0.1
+
+    val_legacy = backend_default.legacy_loglikelihood(
+        theta=theta, omega=omega, tree=wrapped_legacy, log_tau=log_tau
+    )
+    assert jnp.isfinite(val_legacy)

--- a/tests/trees/backend_jax_ragged/test_ragged_benchmarks.py
+++ b/tests/trees/backend_jax_ragged/test_ragged_benchmarks.py
@@ -1,0 +1,106 @@
+import os
+import time
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import numpy.testing as npt
+from anytree import Node
+from pmhn._trees._backend_jax._loglikelihood import loglikelihood as loglikelihood_old
+from pmhn._trees._backend_jax._wrapper import wrap_tree as wrap_tree_old
+from pmhn._trees._backend_jax_ragged import loglikelihood as loglikelihood_new
+from pmhn._trees._backend_jax_ragged import (
+    wrap_tree_ragged,
+)
+
+
+def _tree_small() -> Node:
+    root = Node(0)
+    Node(1, parent=root)
+    return root
+
+
+def _tree_medium() -> Node:
+    root = Node(0)
+    left = Node(1, parent=root)
+    Node(2, parent=root)
+    Node(3, parent=left)
+    return root
+
+
+def _tree_large() -> Node:
+    root = Node(0)
+    left = Node(1, parent=root)
+    right = Node(2, parent=root)
+    Node(3, parent=left)
+    Node(4, parent=right)
+    Node(5, parent=right)
+    return root
+
+
+def test_ragged_path_payload_is_not_larger_than_padded_payload() -> None:
+    trees = [_tree_small(), _tree_medium(), _tree_large()]
+    n_genes = 8
+
+    saw_strict_improvement = False
+
+    for tree in trees:
+        wrapped_old, _ = wrap_tree_old(tree, n_genes=n_genes)
+        wrapped_new, _ = wrap_tree_ragged(tree, n_genes=n_genes)
+
+        padded_payload = int(
+            wrapped_old.diag_paths.path.size + wrapped_old.offdiag_paths.path.size
+        )
+        ragged_payload = int(wrapped_new.paths.events_flat.size)
+
+        assert ragged_payload <= padded_payload
+        if ragged_payload < padded_payload:
+            saw_strict_improvement = True
+
+    # On realistic trees with heterogeneous trajectories, ragged should improve.
+    assert saw_strict_improvement
+
+
+def test_optional_runtime_benchmark_smoke(seed: int = 42) -> None:
+    if os.getenv("PMHN_RUN_BENCHMARKS") != "1":
+        return
+
+    n_genes = 8
+    tree = _tree_large()
+    wrapped_old, _ = wrap_tree_old(tree, n_genes=n_genes)
+    wrapped_new, _ = wrap_tree_ragged(tree, n_genes=n_genes)
+
+    rng = np.random.default_rng(seed)
+    theta = jnp.asarray(rng.normal(size=(n_genes, n_genes)))
+    omega = jnp.asarray(rng.normal(size=(n_genes,)))
+    log_tau = jnp.asarray(0.0)
+
+    old_fn = jax.jit(
+        lambda th, om, lt: loglikelihood_old(th, om, wrapped_old, lt),  # noqa: E731
+    )
+    new_fn = jax.jit(
+        lambda th, om, lt: loglikelihood_new(th, om, wrapped_new, lt),  # noqa: E731
+    )
+
+    # Warm-up (includes compilation).
+    old_value = old_fn(theta, omega, log_tau)
+    new_value = new_fn(theta, omega, log_tau)
+    _ = old_value.block_until_ready()
+    _ = new_value.block_until_ready()
+    npt.assert_allclose(old_value, new_value, atol=1e-6)
+
+    n_runs = 100
+
+    t0 = time.perf_counter()
+    for _ in range(n_runs):
+        _ = old_fn(theta, omega, log_tau).block_until_ready()
+    old_time = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    for _ in range(n_runs):
+        _ = new_fn(theta, omega, log_tau).block_until_ready()
+    new_time = time.perf_counter() - t0
+
+    assert old_time > 0.0
+    assert new_time > 0.0
+    print(f"[benchmark] old_time={old_time:.6f}s new_time={new_time:.6f}s")

--- a/tests/trees/backend_jax_ragged/test_ragged_equinox.py
+++ b/tests/trees/backend_jax_ragged/test_ragged_equinox.py
@@ -1,0 +1,149 @@
+import jax
+import jax.numpy as jnp
+import numpy as np
+import numpy.testing as npt
+import pytest
+from anytree import Node
+
+eqx = pytest.importorskip("equinox")
+optax = pytest.importorskip("optax")
+
+from pmhn._trees._backend_jax_ragged import (  # noqa: E402
+    BilinearLogRateModel,
+    MLPLogRateModel,
+    loglikelihood_many_with_rate_model,
+    loglikelihood_with_rate_model,
+    wrap_tree_ragged,
+)
+from pmhn._trees._backend_jax_ragged._rates import (  # noqa: E402
+    _construct_path_lineage_multihot,
+    _construct_path_log_transition_rates,
+    _construct_path_log_transition_rates_model,
+)
+
+
+def _tree_small() -> Node:
+    root = Node(0)
+    Node(1, parent=root)
+    return root
+
+
+def _tree_medium() -> Node:
+    root = Node(0)
+    left = Node(1, parent=root)
+    Node(2, parent=root)
+    Node(3, parent=left)
+    return root
+
+
+def _tree_large() -> Node:
+    root = Node(0)
+    left = Node(1, parent=root)
+    right = Node(2, parent=root)
+    Node(3, parent=left)
+    Node(4, parent=right)
+    Node(5, parent=right)
+    return root
+
+
+def test_mlp_rate_model_output_shape_and_dtype() -> None:
+    model = MLPLogRateModel(
+        n_genes=6, key=jax.random.PRNGKey(0), width_size=16, depth=1
+    )
+    lineage = jnp.asarray([1, 0, 1, 0, 0, 1], dtype=jnp.float32)
+    out = model(lineage, jnp.asarray(3))
+
+    assert out.shape == ()
+    assert out.dtype == jnp.float32
+
+
+def test_bilinear_model_matches_bilinear_path_rates(seed: int = 1) -> None:
+    n_genes = 6
+    wrapped, _ = wrap_tree_ragged(_tree_medium(), n_genes=n_genes)
+
+    rng = np.random.default_rng(seed)
+    theta = jnp.asarray(rng.normal(size=(n_genes, n_genes)))
+
+    model = BilinearLogRateModel(theta=theta)
+    expected = _construct_path_log_transition_rates(wrapped.paths, theta=theta)
+    obtained = _construct_path_log_transition_rates_model(
+        paths=wrapped.paths,
+        n_genes=n_genes,
+        log_rate_model=model,
+    )
+
+    npt.assert_allclose(obtained, expected, atol=1e-6)
+
+
+def test_model_likelihood_is_jittable_and_gradients_finite(seed: int = 2) -> None:
+    n_genes = 6
+    wrapped, _ = wrap_tree_ragged(_tree_medium(), n_genes=n_genes)
+    model = MLPLogRateModel(n_genes=n_genes, key=jax.random.PRNGKey(11))
+
+    rng = np.random.default_rng(seed)
+    omega = jnp.asarray(rng.normal(size=(n_genes,)))
+    log_tau = jnp.asarray(-0.15)
+
+    @eqx.filter_jit
+    def eval_ll(m, om):
+        return loglikelihood_with_rate_model(m, om, wrapped, log_tau=log_tau)
+
+    value = eval_ll(model, omega)
+    assert jnp.isfinite(value)
+
+    def loss_fn(params):
+        m, om = params
+        return -loglikelihood_with_rate_model(m, om, wrapped, log_tau=log_tau)
+
+    loss_val, grads = eqx.filter_value_and_grad(loss_fn)((model, omega))
+    assert jnp.isfinite(loss_val)
+
+    model_grads, omega_grad = grads
+    leaves = jax.tree_util.tree_leaves(eqx.filter(model_grads, eqx.is_inexact_array))
+    assert all(bool(jnp.all(jnp.isfinite(x))) for x in leaves)
+    assert jnp.all(jnp.isfinite(omega_grad))
+
+
+def test_optax_smoke_one_dataset(seed: int = 3) -> None:
+    n_genes = 6
+    trees = [_tree_small(), _tree_medium(), _tree_large()]
+    wrapped_trees = [wrap_tree_ragged(tree, n_genes=n_genes)[0] for tree in trees]
+
+    model = MLPLogRateModel(n_genes=n_genes, key=jax.random.PRNGKey(31))
+    rng = np.random.default_rng(seed)
+    omega = jnp.asarray(rng.normal(size=(n_genes,)))
+
+    def loss_fn(params):
+        m, om = params
+        ll = loglikelihood_many_with_rate_model(
+            log_rate_model=m,
+            omega=om,
+            trees=wrapped_trees,
+            log_tau=0.0,
+        )
+        return -jnp.mean(ll)
+
+    params = (model, omega)
+    opt = optax.adam(1e-2)
+    opt_state = opt.init(eqx.filter(params, eqx.is_inexact_array))
+
+    loss_initial = loss_fn(params)
+    for _ in range(10):
+        loss_val, grads = eqx.filter_value_and_grad(loss_fn)(params)
+        updates, opt_state = opt.update(
+            grads,
+            opt_state,
+            params=eqx.filter(params, eqx.is_inexact_array),
+        )
+        params = eqx.apply_updates(params, updates)
+        assert jnp.isfinite(loss_val)
+
+    loss_final = loss_fn(params)
+    assert jnp.isfinite(loss_final)
+    assert loss_final <= loss_initial
+
+
+def test_lineage_features_are_binary() -> None:
+    wrapped, _ = wrap_tree_ragged(_tree_large(), n_genes=6)
+    lineage = _construct_path_lineage_multihot(wrapped.paths, n_genes=6)
+    assert jnp.all((lineage == 0.0) | (lineage == 1.0))

--- a/tests/trees/backend_jax_ragged/test_ragged_loglikelihood.py
+++ b/tests/trees/backend_jax_ragged/test_ragged_loglikelihood.py
@@ -1,0 +1,142 @@
+import jax
+import jax.numpy as jnp
+import numpy as np
+import numpy.testing as npt
+from anytree import Node
+from pmhn._trees._backend_jax._loglikelihood import loglikelihood as loglikelihood_old
+from pmhn._trees._backend_jax._wrapper import wrap_tree as wrap_tree_old
+from pmhn._trees._backend_jax_ragged import loglikelihood as loglikelihood_new
+from pmhn._trees._backend_jax_ragged import (
+    loglikelihood_many,
+    wrap_tree_ragged,
+)
+
+
+def _tree_small() -> Node:
+    root = Node(0)
+    Node(1, parent=root)
+    return root
+
+
+def _tree_medium() -> Node:
+    root = Node(0)
+    left = Node(1, parent=root)
+    Node(2, parent=root)
+    Node(3, parent=left)
+    return root
+
+
+def _tree_large() -> Node:
+    root = Node(0)
+    left = Node(1, parent=root)
+    right = Node(2, parent=root)
+    Node(3, parent=left)
+    Node(4, parent=right)
+    Node(5, parent=right)
+    return root
+
+
+def test_loglikelihood_matches_old_implementation(seed: int = 123) -> None:
+    n_genes = 6
+    tree = _tree_medium()
+    wrapped_old, _ = wrap_tree_old(tree, n_genes=n_genes)
+    wrapped_new, _ = wrap_tree_ragged(tree, n_genes=n_genes)
+
+    rng = np.random.default_rng(seed)
+    theta = jnp.asarray(rng.normal(size=(n_genes, n_genes)))
+    omega = jnp.asarray(rng.normal(size=(n_genes,)))
+    log_tau = -0.37
+
+    old_value = loglikelihood_old(
+        theta=theta,
+        omega=omega,
+        tree=wrapped_old,
+        log_tau=log_tau,
+    )
+    new_value = loglikelihood_new(
+        theta=theta,
+        omega=omega,
+        tree=wrapped_new,
+        log_tau=log_tau,
+    )
+
+    npt.assert_allclose(new_value, old_value, atol=1e-6)
+
+
+def test_loglikelihood_gradient_matches_old_implementation(seed: int = 7) -> None:
+    n_genes = 5
+    tree = _tree_medium()
+    wrapped_old, _ = wrap_tree_old(tree, n_genes=n_genes)
+    wrapped_new, _ = wrap_tree_ragged(tree, n_genes=n_genes)
+
+    rng = np.random.default_rng(seed)
+    theta = jnp.asarray(rng.normal(size=(n_genes, n_genes)))
+    omega = jnp.asarray(rng.normal(size=(n_genes,)))
+    log_tau = jnp.asarray(0.11)
+
+    def old_fn(th, om, lt):
+        return loglikelihood_old(theta=th, omega=om, tree=wrapped_old, log_tau=lt)
+
+    def new_fn(th, om, lt):
+        return loglikelihood_new(theta=th, omega=om, tree=wrapped_new, log_tau=lt)
+
+    grad_old = jax.grad(old_fn, argnums=(0, 1, 2))(theta, omega, log_tau)
+    grad_new = jax.grad(new_fn, argnums=(0, 1, 2))(theta, omega, log_tau)
+
+    npt.assert_allclose(grad_new[0], grad_old[0], atol=1e-6)
+    npt.assert_allclose(grad_new[1], grad_old[1], atol=1e-6)
+    npt.assert_allclose(grad_new[2], grad_old[2], atol=1e-6)
+
+
+def test_new_loglikelihood_is_jittable(seed: int = 22) -> None:
+    n_genes = 5
+    tree = _tree_medium()
+    wrapped_new, _ = wrap_tree_ragged(tree, n_genes=n_genes)
+
+    rng = np.random.default_rng(seed)
+    theta = jnp.asarray(rng.normal(size=(n_genes, n_genes)))
+    omega = jnp.asarray(rng.normal(size=(n_genes,)))
+    log_tau = jnp.asarray(-0.2)
+
+    def fn(th, om, lt):
+        return loglikelihood_new(theta=th, omega=om, tree=wrapped_new, log_tau=lt)
+
+    value_eager = fn(theta, omega, log_tau)
+    value_jit = jax.jit(fn)(theta, omega, log_tau)
+    grad_jit = jax.jit(jax.grad(fn, argnums=0))(theta, omega, log_tau)
+
+    npt.assert_allclose(value_jit, value_eager, atol=1e-6)
+    assert grad_jit.shape == theta.shape
+    assert jnp.all(jnp.isfinite(grad_jit))
+
+
+def test_apply_new_implementation_to_three_trees_of_different_sizes(
+    seed: int = 5,
+) -> None:
+    n_genes = 6
+    trees = [_tree_small(), _tree_medium(), _tree_large()]
+    wrapped_old = [wrap_tree_old(tree, n_genes=n_genes)[0] for tree in trees]
+    wrapped_new = [wrap_tree_ragged(tree, n_genes=n_genes)[0] for tree in trees]
+
+    rng = np.random.default_rng(seed)
+    theta = jnp.asarray(rng.normal(size=(n_genes, n_genes)))
+    omega = jnp.asarray(rng.normal(size=(n_genes,)))
+    log_tau = 0.09
+
+    values_old = jnp.asarray(
+        [
+            loglikelihood_old(theta=theta, omega=omega, tree=tree, log_tau=log_tau)
+            for tree in wrapped_old
+        ]
+    )
+
+    # Heterogeneous tree sizes: evaluate in a Python loop via helper API.
+    values_new = loglikelihood_many(
+        theta=theta,
+        omega=omega,
+        trees=wrapped_new,
+        log_tau=log_tau,
+    )
+
+    assert values_new.shape == (3,)
+    npt.assert_allclose(values_new, values_old, atol=1e-6)

--- a/tests/trees/backend_jax_ragged/test_ragged_rates.py
+++ b/tests/trees/backend_jax_ragged/test_ragged_rates.py
@@ -1,3 +1,4 @@
+import jax
 import jax.numpy as jnp
 import numpy as np
 import numpy.testing as npt
@@ -99,3 +100,43 @@ def test_construct_log_magic_matrix_parity_with_padded_backend(
     )
 
     npt.assert_allclose(magic_ragged.to_dense(), magic_padded.to_dense(), atol=1e-6)
+
+
+def test_segment_logsumexp_safe_for_all_inf_and_empty_segments() -> None:
+    data = jnp.asarray([-jnp.inf, -jnp.inf, 0.0, -3.0])
+    segment_ids = jnp.asarray([0, 0, 2, 2])
+
+    obtained = rates_ragged.segment_logsumexp(
+        data=data,
+        segment_ids=segment_ids,
+        num_segments=4,
+    )
+
+    expected = jnp.asarray(
+        [
+            -jnp.inf,  # all -inf
+            -jnp.inf,  # empty segment
+            jnp.log(jnp.exp(0.0) + jnp.exp(-3.0)),
+            -jnp.inf,  # empty segment
+        ]
+    )
+
+    assert not jnp.any(jnp.isnan(obtained))
+    npt.assert_allclose(obtained, expected, atol=1e-6)
+
+
+def test_segment_logsumexp_gradients_are_finite() -> None:
+    segment_ids = jnp.asarray([0, 0, 1, 2])
+
+    def objective(x):
+        data = jnp.asarray([x[0], x[1], -jnp.inf, x[2]])
+        y = rates_ragged.segment_logsumexp(
+            data=data,
+            segment_ids=segment_ids,
+            num_segments=3,
+        )
+        return jnp.where(jnp.isfinite(y), y, 0.0).sum()
+
+    x = jnp.asarray([-1000.0, -1001.0, -999.0])
+    g = jax.grad(objective)(x)
+    assert jnp.all(jnp.isfinite(g))

--- a/tests/trees/backend_jax_ragged/test_ragged_rates.py
+++ b/tests/trees/backend_jax_ragged/test_ragged_rates.py
@@ -1,0 +1,101 @@
+import jax.numpy as jnp
+import numpy as np
+import numpy.testing as npt
+import pmhn._trees._backend_jax._rates as rates_padded
+import pmhn._trees._backend_jax_ragged._rates as rates_ragged
+from anytree import Node
+from pmhn._trees._backend_jax._wrapper import wrap_tree
+from pmhn._trees._backend_jax_ragged._wrapper import wrap_tree_ragged
+
+
+def _decode_path(wrapped_ragged, path_id: int) -> tuple[int, ...]:
+    ptr = np.asarray(wrapped_ragged.paths.path_ptr)
+    events = np.asarray(wrapped_ragged.paths.events_flat)
+    return tuple(events[ptr[path_id] : ptr[path_id + 1]].tolist())
+
+
+def _build_tree() -> Node:
+    root = Node(0)
+    left = Node(1, parent=root)
+    Node(2, parent=root)
+    Node(3, parent=left)
+    return root
+
+
+def test_path_log_transition_rates_match_padded_reference(seed: int = 7) -> None:
+    tree = _build_tree()
+    n_genes = 5
+    wrapped_ragged, _ = wrap_tree_ragged(tree, n_genes=n_genes)
+
+    rng = np.random.default_rng(seed)
+    theta = jnp.asarray(rng.normal(size=(n_genes, n_genes)))
+    extended_theta = rates_padded._extend_theta(theta)
+
+    obtained = rates_ragged._construct_path_log_transition_rates(
+        paths=wrapped_ragged.paths, theta=theta
+    )
+    expected = jnp.asarray(
+        [
+            rates_padded._construct_log_transtion_rate(
+                jnp.asarray(_decode_path(wrapped_ragged, path_id), dtype=int),
+                extended_theta,
+            )
+            for path_id in range(wrapped_ragged.paths.n_paths)
+        ]
+    )
+
+    npt.assert_allclose(obtained, expected, atol=1e-6)
+
+
+def test_path_log_exit_rates_match_padded_reference(seed: int = 9) -> None:
+    tree = _build_tree()
+    n_genes = 5
+    wrapped_ragged, _ = wrap_tree_ragged(tree, n_genes=n_genes)
+
+    rng = np.random.default_rng(seed)
+    omega = jnp.asarray(rng.normal(size=(n_genes,)))
+    extended_omega = rates_padded._extend_omega(omega)
+
+    obtained = rates_ragged._construct_path_log_exit_rates(
+        paths=wrapped_ragged.paths, omega=omega
+    )
+    expected = jnp.asarray(
+        [
+            rates_padded._construct_log_exit_rate(
+                jnp.asarray(_decode_path(wrapped_ragged, path_id), dtype=int),
+                extended_omega,
+            )
+            for path_id in range(wrapped_ragged.paths.n_paths)
+        ]
+    )
+
+    npt.assert_allclose(obtained, expected, atol=1e-6)
+
+
+def test_construct_log_magic_matrix_parity_with_padded_backend(
+    seed: int = 123,
+) -> None:
+    tree = _build_tree()
+    n_genes = 5
+    wrapped_padded, _ = wrap_tree(tree, n_genes=n_genes)
+    wrapped_ragged, _ = wrap_tree_ragged(tree, n_genes=n_genes)
+
+    rng = np.random.default_rng(seed)
+    theta = jnp.asarray(rng.normal(size=(n_genes, n_genes)))
+    omega = jnp.asarray(rng.normal(size=(n_genes,)))
+    log_tau = 0.27
+
+    magic_padded = rates_padded._construct_log_magic_matrix(
+        tree=wrapped_padded,
+        theta=theta,
+        omega=omega,
+        log_tau=log_tau,
+    )
+    magic_ragged = rates_ragged._construct_log_magic_matrix(
+        tree=wrapped_ragged,
+        theta=theta,
+        omega=omega,
+        log_tau=log_tau,
+    )
+
+    npt.assert_allclose(magic_ragged.to_dense(), magic_padded.to_dense(), atol=1e-6)

--- a/tests/trees/backend_jax_ragged/test_ragged_solver.py
+++ b/tests/trees/backend_jax_ragged/test_ragged_solver.py
@@ -1,0 +1,106 @@
+import jax.numpy as jnp
+import numpy as np
+import numpy.testing as npt
+import pmhn._trees._backend_jax._rates as rates_padded
+from anytree import Node
+from pmhn._trees._backend_jax._solver import logprob_forward_substitution as solver_old
+from pmhn._trees._backend_jax._sparse import coo_matrix_from_array
+from pmhn._trees._backend_jax._wrapper import wrap_tree as wrap_tree_old
+from pmhn._trees._backend_jax_ragged._rates import _construct_log_magic_matrix
+from pmhn._trees._backend_jax_ragged._solver import (
+    logprob_forward_substitution_layerwise as solver_new,
+)
+from pmhn._trees._backend_jax_ragged._wrapper import wrap_tree_ragged
+
+
+def _build_tree() -> Node:
+    root = Node(0)
+    left = Node(1, parent=root)
+    Node(2, parent=root)
+    Node(3, parent=left)
+    return root
+
+
+def _solve_dense_reference(log_magic_dense: np.ndarray) -> np.ndarray:
+    """Dense reference solver for the transformed triangular system."""
+    a = np.exp(log_magic_dense)
+    size = a.shape[0]
+
+    # Build B x = e0 where:
+    #   B[i, i] = V_ii
+    #   B[i, s] = -Q_{s, i} for s != i
+    b = np.diag(np.diag(a))
+    for s in range(size):
+        for e in range(size):
+            if s == e:
+                continue
+            b[e, s] = -a[s, e]
+
+    rhs = np.zeros(size)
+    rhs[0] = 1.0
+    x = np.linalg.solve(b, rhs)
+    return np.log(x)
+
+
+def test_layerwise_solver_matches_old_solver(seed: int = 12) -> None:
+    tree = _build_tree()
+    n_genes = 5
+
+    wrapped_old, _ = wrap_tree_old(tree, n_genes=n_genes)
+    wrapped_new, _ = wrap_tree_ragged(tree, n_genes=n_genes)
+
+    rng = np.random.default_rng(seed)
+    theta = jnp.asarray(rng.normal(size=(n_genes, n_genes)))
+    omega = jnp.asarray(rng.normal(size=(n_genes,)))
+    log_tau = -0.21
+
+    log_magic_old = rates_padded._construct_log_magic_matrix(
+        tree=wrapped_old,
+        theta=theta,
+        omega=omega,
+        log_tau=log_tau,
+    )
+    log_magic_new = _construct_log_magic_matrix(
+        tree=wrapped_new,
+        theta=theta,
+        omega=omega,
+        log_tau=log_tau,
+    )
+
+    old_values = solver_old(log_magic_old)
+    new_values = solver_new(
+        log_magic=log_magic_new,
+        node_layer=wrapped_new.node_layer,
+        layer_ptr=wrapped_new.layer_ptr,
+    )
+    npt.assert_allclose(new_values, old_values, atol=1e-6)
+
+
+def test_layerwise_solver_matches_dense_reference() -> None:
+    # Same synthetic system as the legacy solver test.
+    q = 0.1 * np.asarray(
+        [
+            [0, 7, 5, 0],
+            [0, 0, 2, 1],
+            [0, 0, 0, 2],
+            [0, 0, 0, 0],
+        ]
+    )
+    q -= q.sum(axis=1) * np.eye(q.shape[0])
+
+    v = np.eye(q.shape[0]) - q
+    log_magic_dense = np.log(np.abs(v))
+    log_magic = coo_matrix_from_array(jnp.asarray(log_magic_dense))
+
+    # Nodes are ordered by increasing subtree size in practice; here use 1-node layers.
+    node_layer = jnp.arange(log_magic.size, dtype=int)
+    layer_ptr = jnp.arange(log_magic.size + 1, dtype=int)
+
+    obtained = solver_new(
+        log_magic=log_magic,
+        node_layer=node_layer,
+        layer_ptr=layer_ptr,
+    )
+    expected = _solve_dense_reference(log_magic_dense)
+
+    npt.assert_allclose(obtained, expected, atol=1e-6)

--- a/tests/trees/backend_jax_ragged/test_ragged_wrapper.py
+++ b/tests/trees/backend_jax_ragged/test_ragged_wrapper.py
@@ -101,14 +101,19 @@ def test_wrap_tree_ragged_pointer_and_last_event_consistency() -> None:
 
     ptr = np.asarray(wrapped.paths.path_ptr)
     events = np.asarray(wrapped.paths.events_flat)
+    event_path_id = np.asarray(wrapped.paths.event_path_id)
     last = np.asarray(wrapped.paths.path_last_event)
 
     assert ptr[0] == 0
     assert ptr[-1] == events.shape[0]
     assert np.all(ptr[1:] > ptr[:-1])
+    assert event_path_id.shape[0] == events.shape[0]
     assert wrapped.paths.n_paths == last.shape[0]
 
     for path_id in range(wrapped.paths.n_paths):
         decoded = _decode_path(wrapped, path_id)
         assert len(decoded) > 0
         assert decoded[-1] == int(last[path_id])
+        start = int(ptr[path_id])
+        end = int(ptr[path_id + 1])
+        assert np.all(event_path_id[start:end] == path_id)

--- a/tests/trees/backend_jax_ragged/test_wrapper.py
+++ b/tests/trees/backend_jax_ragged/test_wrapper.py
@@ -1,0 +1,114 @@
+import numpy as np
+from anytree import Node
+from pmhn._trees._backend_jax_ragged import wrap_tree_ragged
+from pmhn._trees._tree_utils import construct_paths_matrix
+
+
+def _decode_path(wrapped, path_id: int) -> tuple[int, ...]:
+    events = np.asarray(wrapped.paths.events_flat)
+    ptr = np.asarray(wrapped.paths.path_ptr)
+    start = int(ptr[path_id])
+    end = int(ptr[path_id + 1])
+    return tuple(events[start:end].tolist())
+
+
+def _build_tree() -> Node:
+    root = Node(0)
+    left = Node(1, parent=root)
+    Node(2, parent=root)
+    Node(3, parent=left)
+    return root
+
+
+def test_wrap_tree_ragged_offdiag_paths_match_original() -> None:
+    tree = _build_tree()
+    n_genes = 4
+
+    wrapped, _ = wrap_tree_ragged(tree, n_genes=n_genes)
+    paths_matrix = construct_paths_matrix(tree, n_genes=n_genes)
+
+    expected = {
+        (start, end): tuple(traj)[1:]
+        for (start, end), traj in paths_matrix.offdiag.items()
+    }
+    obtained = {
+        (int(start), int(end)): _decode_path(wrapped, int(path_id))
+        for start, end, path_id in zip(
+            np.asarray(wrapped.edge_start),
+            np.asarray(wrapped.edge_end),
+            np.asarray(wrapped.edge_path_id),
+        )
+    }
+
+    assert expected == obtained
+
+
+def test_wrap_tree_ragged_diag_and_exit_paths_match_original_multiset() -> None:
+    tree = _build_tree()
+    n_genes = 4
+
+    wrapped, _ = wrap_tree_ragged(tree, n_genes=n_genes)
+    paths_matrix = construct_paths_matrix(tree, n_genes=n_genes)
+
+    expected = sorted(
+        (subtree_id, tuple(traj)[1:])
+        for subtree_id, trajs in enumerate(paths_matrix.diag)
+        for traj in trajs
+    )
+    obtained_diag = sorted(
+        (int(subtree_id), _decode_path(wrapped, int(path_id)))
+        for subtree_id, path_id in zip(
+            np.asarray(wrapped.diag_subtree_id),
+            np.asarray(wrapped.diag_path_id),
+        )
+    )
+    obtained_exit = sorted(
+        (int(subtree_id), _decode_path(wrapped, int(path_id)))
+        for subtree_id, path_id in zip(
+            np.asarray(wrapped.exit_subtree_id),
+            np.asarray(wrapped.exit_path_id),
+        )
+    )
+
+    assert expected == obtained_diag
+    assert expected == obtained_exit
+
+
+def test_wrap_tree_ragged_layer_metadata_is_valid() -> None:
+    tree = _build_tree()
+    wrapped, _ = wrap_tree_ragged(tree, n_genes=4)
+
+    node_layer = np.asarray(wrapped.node_layer)
+    layer_ptr = np.asarray(wrapped.layer_ptr)
+    edge_start = np.asarray(wrapped.edge_start)
+    edge_end = np.asarray(wrapped.edge_end)
+
+    assert layer_ptr[0] == 0
+    assert layer_ptr[-1] == wrapped.n_subtrees
+    assert wrapped.n_layers == int(node_layer.max()) + 1
+
+    for i in range(wrapped.n_layers):
+        begin = int(layer_ptr[i])
+        end = int(layer_ptr[i + 1])
+        assert np.all(node_layer[begin:end] == i)
+
+    assert np.all(node_layer[edge_end] == node_layer[edge_start] + 1)
+
+
+def test_wrap_tree_ragged_pointer_and_last_event_consistency() -> None:
+    tree = _build_tree()
+    wrapped, _ = wrap_tree_ragged(tree, n_genes=4)
+
+    ptr = np.asarray(wrapped.paths.path_ptr)
+    events = np.asarray(wrapped.paths.events_flat)
+    last = np.asarray(wrapped.paths.path_last_event)
+
+    assert ptr[0] == 0
+    assert ptr[-1] == events.shape[0]
+    assert np.all(ptr[1:] > ptr[:-1])
+    assert wrapped.paths.n_paths == last.shape[0]
+
+    for path_id in range(wrapped.paths.n_paths):
+        decoded = _decode_path(wrapped, path_id)
+        assert len(decoded) > 0
+        assert decoded[-1] == int(last[path_id])


### PR DESCRIPTION
This PR:
  - migrates the tree JAX backend from padded trajectory encoding to a ragged representation,
  - introduces a layer-parallel solver, adds a general Equinox model interface for transition log-rates, and 
  - switches the public `pmhn._trees._backend_jax` API to ragged-first defaults (with legacy padded API preserved).

## Why this change?

The previous padded path encoding required rectangular path tensors (`K x Lmax`), which:

1. Wasted memory for heterogeneous path lengths.
2. Added implementation complexity via padding constants.
3. Limited extensibility for non-bilinear rate models.

This PR introduces a ragged format (`events_flat + path_ptr + event_path_id`) to reduce padding overhead and enable more flexible rate parameterizations.

## Main changes

## 1. New ragged tree backend

Added new package `src/pmhn/_trees/_backend_jax_ragged/`

## 2. Layer-parallel solver

Added:

1. `logprob_forward_substitution_layerwise(...)`

It updates one subtree-size layer at a time and uses segment reductions for incoming contributions, which is more GPU-friendly than purely node-sequential updates.

## 3. Equinox model support

Added model classes:

1. `BilinearLogRateModel`
2. `MLPLogRateModel`

Added likelihood entrypoints:

1. `loglikelihood_with_rate_model(...)`
2. `loglikelihood_many_with_rate_model(...)`

This enables replacing the bilinear `theta` form with a general neural model while keeping the same solver structure.

## 4. Numerical stability hardening

`segment_logsumexp` in ragged rates now handles all-`-inf` and empty segments safely:

1. returns `-inf` instead of `NaN`
2. gradient behavior tested for finiteness

## 5. Public API migration

Updated:

1. `src/pmhn/_trees/_backend_jax/__init__.py`

Now default exports are ragged-first:

1. `wrap_tree` now aliases `wrap_tree_ragged`
2. `loglikelihood` now points to ragged implementation

Legacy padded API preserved under explicit names:

1. `legacy_wrap_tree`
2. `legacy_loglikelihood`
3. `LegacyWrappedTree`, `LegacyIndexedPaths`, `LegacyDoublyIndexedPaths`, `LegacyExitPathsArray`

## Tests added and expanded

Covered behaviors include:

1. Ragged wrapper correctness and invariants
2. Rate parity with legacy padded backend
3. Solver parity with legacy solver and dense reference
4. Loglikelihood parity and gradient parity
5. JIT compatibility
6. Heterogeneous list-of-trees evaluation
7. Equinox model forward/grad/train-smoke checks
8. Memory proxy and optional runtime benchmark smoke
9. Backward-compatible legacy API availability

## Benchmark hooks

Added optional benchmark test gated by env var:

1. `PMHN_RUN_BENCHMARKS=1`

This keeps CI stable while allowing local runtime comparisons.

## Migration notes for users

Default behavior from `pmhn._trees._backend_jax` is now ragged.

If padded behavior is still needed temporarily, use:

1. `legacy_wrap_tree(...)`
2. `legacy_loglikelihood(...)`

## Follow-up items (not required for this PR)

1. Add bucketed/batched execution strategies for large heterogeneous datasets.
2. Decide timeline for deprecating/removing legacy padded API.
3. Run hardware-specific benchmarks (CPU/GPU) on representative production tree sets.